### PR TITLE
SCB-1118 Catch the exception to keep EventScanner running

### DIFF
--- a/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/EventScanner.java
+++ b/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/EventScanner.java
@@ -71,7 +71,12 @@ public class EventScanner implements Runnable {
 
   @Override
   public void run() {
-    pollEvents();
+    try {
+      // Need to catch the exception to keep the event scanner running.
+      pollEvents();
+    } catch (Exception ex) {
+      LOG.warn("Got the exception {} when pollEvents.", ex.getMessage(), ex);
+    }
   }
 
   private void pollEvents() {


### PR DESCRIPTION
Catching the EventScanner.polleEvents() exception To fix the issue of #382.