### PR TITLE
[SCB-1130] Dynamically configure the master node base on master_lock …

### DIFF
--- a/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/NodeStatus.java
+++ b/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/NodeStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.core;
+
+public class NodeStatus {
+    private TypeEnum typeEnum = TypeEnum.SLAVE;
+
+    public NodeStatus(TypeEnum typeNnum) {
+        this.typeEnum = typeNnum;
+    }
+
+    public void setTypeEnum(TypeEnum typeNnum) {
+        this.typeEnum = typeNnum;
+    }
+
+    public TypeEnum getTypeEnum() {
+        return typeEnum;
+    }
+
+    public enum TypeEnum {
+        MASTER, SLAVE
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
@@ -106,6 +106,9 @@ public class ClusterLockService implements ApplicationListener<ApplicationReadyE
         this.masterLock = masterLock;
     }
 
+    /**
+     * Try to lock every second
+     * */
     @Scheduled(cron = "0/1 * * * * ?")
     public void masterCheck() {
         if (applicationReady) {

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
@@ -92,15 +92,13 @@ public class ClusterLockService implements ApplicationListener<ApplicationReadyE
 
     public MasterLock getMasterLock() {
         if (this.masterLock == null) {
-            this.masterLock = new MasterLock();
-            this.masterLock.setServiceName(serviceName);
-            this.masterLock.setInstanceId(instanceId);
+            this.masterLock = new MasterLock(serviceName,instanceId);
         }
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
+        this.masterLock.setLockedTime(cal.getTime());
         cal.add(Calendar.MILLISECOND, expire);
         this.masterLock.setExpireTime(cal.getTime());
-        this.masterLock.setLockedTime(new Date());
         return this.masterLock;
     }
 

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master;
+
+import org.apache.servicecomb.pack.alpha.core.NodeStatus;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.LockProvider;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.Locker;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * Cluster master preemption master service
+ * default based on database master_lock table implementation
+ * <p>
+ * Set true to enable default value false
+ * alpha.cluster.master.enabled=true
+ * <p>
+ * Implementation type, default jdbc
+ * alpha.cluster.master.type=jdbc
+ * <p>
+ * Lock timeout, default value 5000 millisecond
+ * alpha.cluster.master.expire=5000
+ */
+
+@Component
+@ConditionalOnProperty(name = "alpha.cluster.master.enabled", havingValue = "true")
+@EnableScheduling
+public class ClusterLockService implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private boolean locked = Boolean.FALSE;
+    private boolean lockExecuted = Boolean.FALSE;
+    private boolean applicationReady = Boolean.FALSE;
+    private MasterLock masterLock;
+    private Optional<Locker> locker;
+
+    @Value("[${alpha.server.host}]:${alpha.server.port}")
+    private String instanceId;
+
+    @Value("${spring.application.name:servicecomb-alpha-server}")
+    private String serviceName;
+
+    @Value("${alpha.cluster.master.expire:5000}")
+    private int expire;
+
+    @Autowired
+    LockProvider lockProvider;
+
+    @Autowired
+    NodeStatus nodeStatus;
+
+    public ClusterLockService() {
+        LOG.info("Initialize cluster mode");
+    }
+
+    public boolean isMasterNode() {
+        return locked;
+    }
+
+    public boolean isLockExecuted() {
+        return lockExecuted;
+    }
+
+    public MasterLock getMasterLock() {
+        if (this.masterLock == null) {
+            this.masterLock = new MasterLock();
+            this.masterLock.setServiceName(serviceName);
+            this.masterLock.setInstanceId(instanceId);
+        }
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.MILLISECOND, expire);
+        this.masterLock.setExpireTime(cal.getTime());
+        this.masterLock.setLockedTime(new Date());
+        return this.masterLock;
+    }
+
+    public void setMasterLock(MasterLock masterLock) {
+        this.masterLock = masterLock;
+    }
+
+    @Scheduled(cron = "0/1 * * * * ?")
+    public void masterCheck() {
+        if (applicationReady) {
+            this.locker = lockProvider.lock(this.getMasterLock());
+            if (this.locker.isPresent()) {
+                if (!this.locked) {
+                    this.locked = true;
+                    nodeStatus.setTypeEnum(NodeStatus.TypeEnum.MASTER);
+                    LOG.info("Master Node");
+                }
+                //Keep locked
+            } else {
+                if (this.locked || !lockExecuted) {
+                    locked = false;
+                    nodeStatus.setTypeEnum(NodeStatus.TypeEnum.SLAVE);
+                    LOG.info("Slave Node");
+                }
+            }
+            lockExecuted = Boolean.TRUE;
+        }
+    }
+
+    public void unLock(){
+        if(this.locker.isPresent()){
+            this.locker.get().unlock();
+        }
+        lockExecuted = false;
+        locked = false;
+        nodeStatus.setTypeEnum(NodeStatus.TypeEnum.SLAVE);
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent applicationReadyEvent) {
+        this.applicationReady = Boolean.TRUE;
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/AbstractLockProvider.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/AbstractLockProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+
+import java.util.Optional;
+
+public abstract class AbstractLockProvider implements LockProvider {
+
+    private final LockProviderPersistence lockProviderPersistence;
+    private Boolean lockInitialization = Boolean.FALSE;
+
+    protected AbstractLockProvider(LockProviderPersistence lockProviderPersistence) {
+        this.lockProviderPersistence = lockProviderPersistence;
+    }
+
+    @Override
+    public Optional<org.apache.servicecomb.pack.alpha.server.cluster.master.provider.Locker> lock(MasterLock masterLock) {
+        boolean lockObtained = doLock(masterLock);
+        if (lockObtained) {
+            return Optional.of(new Locker(masterLock, lockProviderPersistence));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    protected boolean doLock(MasterLock masterLock) {
+        if (!lockInitialization) {
+            if (lockProviderPersistence.initLock(masterLock)) {
+                lockInitialization = Boolean.TRUE;
+                return true;
+            }
+            lockInitialization = Boolean.TRUE;
+        }
+        return lockProviderPersistence.updateLock(masterLock);
+    }
+
+    private static class Locker implements org.apache.servicecomb.pack.alpha.server.cluster.master.provider.Locker {
+        private final MasterLock masterLock;
+        private final LockProviderPersistence lockProviderPersistence;
+
+        Locker(MasterLock masterLock, LockProviderPersistence lockProviderPersistence) {
+            this.masterLock = masterLock;
+            this.lockProviderPersistence = lockProviderPersistence;
+        }
+
+        @Override
+        public void unlock() {
+            lockProviderPersistence.unLock(masterLock);
+        }
+    }
+
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/LockProvider.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/LockProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+
+import java.util.Optional;
+
+public interface LockProvider {
+    Optional<Locker> lock(MasterLock masterLock);
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/LockProviderPersistence.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/LockProviderPersistence.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+
+public interface LockProviderPersistence {
+
+    boolean initLock(MasterLock masterLock);
+
+    boolean updateLock(MasterLock masterLock);
+
+    void unLock(MasterLock masterLock);
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/Locker.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/Locker.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider;
+
+public interface Locker {
+    void unlock();
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/JdbcLockPersistence.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/JdbcLockPersistence.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.LockProviderPersistence;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLockRepository;
+
+class JdbcLockPersistence implements LockProviderPersistence {
+
+    private final MasterLockRepository masterLockRepository;
+
+    JdbcLockPersistence(MasterLockRepository masterLockRepository) {
+        this.masterLockRepository = masterLockRepository;
+    }
+
+    public boolean initLock(MasterLock masterLock) {
+        return this.masterLockRepository.initLock(masterLock);
+    }
+
+    public boolean updateLock(MasterLock masterLock) {
+        return this.masterLockRepository.updateLock(masterLock);
+    }
+
+    public void unLock(MasterLock masterLock) {
+        this.masterLockRepository.unLock(masterLock.getServiceName(),
+                masterLock.getExpireTime());
+    }
+
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/JdbcLockProvider.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/JdbcLockProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.AbstractLockProvider;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLockRepository;
+
+public class JdbcLockProvider extends AbstractLockProvider {
+    public JdbcLockProvider(MasterLockRepository masterLockRepository) {
+        super(new JdbcLockPersistence(masterLockRepository));
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/LockProviderJdbcConfiguration.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/LockProviderJdbcConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.LockProvider;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLockRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@ConditionalOnProperty(name = "alpha.cluster.master.enabled", havingValue = "true")
+public class LockProviderJdbcConfiguration {
+
+    @Bean
+    public MasterLockRepository springElectionRepository(MasterLockEntityRepository electionRepo) {
+        return new SpringMasterLockRepository(electionRepo);
+    }
+
+    @Primary
+    @Bean
+    @ConditionalOnProperty(name = "alpha.cluster.master.type", havingValue = "jdbc", matchIfMissing = true)
+    public LockProvider lockProvider(MasterLockRepository electionRepo) {
+        return new JdbcLockProvider(electionRepo);
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/MasterLockEntityRepository.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/MasterLockEntityRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc;
+
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import javax.transaction.Transactional;
+import java.util.Date;
+import java.util.Optional;
+
+interface MasterLockEntityRepository extends CrudRepository<MasterLock, String> {
+
+    Optional<MasterLock> findMasterLockByServiceName(String serviceName);
+
+    @Transactional
+    @Modifying
+    @Query(value = "INSERT INTO master_lock "
+            + "(serviceName, expireTime, lockedTime, instanceId) "
+            + "VALUES "
+            + "(?1, ?2, ?3, ?4)", nativeQuery = true)
+    int initLock(
+            @Param("serviceName") String serviceName,
+            @Param("expireTime") Date expireTime,
+            @Param("lockedTime") Date lockedTime,
+            @Param("instanceId") String instanceId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock t "
+            + "SET t.expireTime = :expireTime"
+            + ",t.lockedTime = :lockedTime "
+            + ",t.instanceId = :instanceId "
+            + "WHERE t.serviceName = :serviceName AND (t.expireTime <= :lockedTime OR t.instanceId = :instanceId)")
+    int updateLock(
+            @Param("serviceName") String serviceName,
+            @Param("lockedTime") Date lockedTime,
+            @Param("expireTime") Date expireTime,
+            @Param("instanceId") String instanceId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock t "
+            + "SET t.expireTime = :expireTime "
+            + "WHERE t.serviceName = :serviceName")
+    int unLock(@Param("serviceName") String serviceName,
+               @Param("expireTime") Date expireTime);
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/SpringMasterLockRepository.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/SpringMasterLockRepository.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc;
+
+import kamon.annotation.EnableKamon;
+import kamon.annotation.Segment;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLockRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Date;
+import java.util.Optional;
+
+@EnableKamon
+@ConditionalOnProperty(name = "alpha.cluster.master.enabled", havingValue = "true")
+public class SpringMasterLockRepository implements MasterLockRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final MasterLockEntityRepository electionRepo;
+
+    SpringMasterLockRepository(MasterLockEntityRepository electionRepo) {
+        this.electionRepo = electionRepo;
+    }
+
+    @Override
+    @Segment(name = "MasterLockInit", category = "application", library = "kamon")
+    public boolean initLock(MasterLock masterLock) {
+        try {
+            Optional<MasterLock> lock = this.findMasterLockByServiceName(masterLock.getServiceName());
+            if (!lock.isPresent()) {
+                electionRepo.initLock(masterLock.getServiceName(),
+                        masterLock.getExpireTime(),
+                        masterLock.getLockedTime(),
+                        masterLock.getInstanceId());
+                return true;
+            } else {
+                return false;
+            }
+        } catch (Exception e) {
+            LOG.error("Init lock error",e);
+            return false;
+        }
+    }
+
+    @Override
+    @Segment(name = "MasterUpdateLock", category = "application", library = "kamon")
+    public boolean updateLock(MasterLock masterLock) {
+        try {
+            int size = electionRepo.updateLock(
+                    masterLock.getServiceName(),
+                    new Date(),
+                    masterLock.getExpireTime(),
+                    masterLock.getInstanceId());
+            return size > 0 ? true : false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    @Segment(name = "MasterUnLock", category = "application", library = "kamon")
+    public void unLock(String serviceName, Date expireTime) {
+        electionRepo.unLock(serviceName, expireTime);
+    }
+
+    @Override
+    public Optional<MasterLock> findMasterLockByServiceName(String serviceName) {
+        return electionRepo.findMasterLockByServiceName(serviceName);
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/SpringMasterLockRepository.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/SpringMasterLockRepository.java
@@ -72,6 +72,7 @@ public class SpringMasterLockRepository implements MasterLockRepository {
                     masterLock.getInstanceId());
             return size > 0 ? true : false;
         } catch (Exception e) {
+            LOG.error("Update lock error",e);
             return false;
         }
     }

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLock.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLock.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+@Entity
+@Table(name = "master_lock")
+public class MasterLock {
+
+    @Id
+    private String serviceName;
+    private String instanceId;
+    private Date expireTime;
+    private Date lockedTime;
+
+    public MasterLock() {
+
+    }
+
+    public MasterLock(MasterLock masterLock) {
+        this(masterLock.serviceName,
+                masterLock.instanceId,
+                masterLock.expireTime,
+                masterLock.lockedTime);
+    }
+
+    public MasterLock(
+            String serviceName,
+            String instanceId,
+            Date expireTime,
+            Date lockedTime) {
+        this.serviceName = serviceName;
+        this.instanceId = instanceId;
+        this.expireTime = expireTime;
+        this.lockedTime = lockedTime;
+    }
+
+    public Date getExpireTime() {
+        return expireTime;
+    }
+
+    public void setExpireTime(Date expireTime) {
+        this.expireTime = expireTime;
+    }
+
+    public Date getLockedTime() {
+        return lockedTime;
+    }
+
+    public void setLockedTime(Date lockedTime) {
+        this.lockedTime = lockedTime;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+}

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLock.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLock.java
@@ -32,26 +32,15 @@ public class MasterLock {
     private Date expireTime;
     private Date lockedTime;
 
-    public MasterLock() {
+    public MasterLock(){
 
-    }
-
-    public MasterLock(MasterLock masterLock) {
-        this(masterLock.serviceName,
-                masterLock.instanceId,
-                masterLock.expireTime,
-                masterLock.lockedTime);
     }
 
     public MasterLock(
             String serviceName,
-            String instanceId,
-            Date expireTime,
-            Date lockedTime) {
+            String instanceId) {
         this.serviceName = serviceName;
         this.instanceId = instanceId;
-        this.expireTime = expireTime;
-        this.lockedTime = lockedTime;
     }
 
     public Date getExpireTime() {

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLockRepository.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/provider/jdbc/jpa/MasterLockRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa;
+
+import java.util.Date;
+import java.util.Optional;
+
+public interface MasterLockRepository {
+
+    boolean initLock(MasterLock masterLock);
+
+    boolean updateLock(MasterLock masterLock);
+
+    void unLock(String serviceName, Date expireTime);
+
+    Optional<MasterLock> findMasterLockByServiceName(String serviceName);
+}

--- a/alpha/alpha-server/src/main/resources/schema-mysql.sql
+++ b/alpha/alpha-server/src/main/resources/schema-mysql.sql
@@ -113,3 +113,12 @@ CREATE TABLE IF NOT EXISTS tcc_tx_event (
   PRIMARY KEY (surrogateId),
   UNIQUE INDEX tcc_tx_event_index (globalTxId, localTxId, parentTxId, txType)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS master_lock (
+  serviceName varchar(36) not NULL,
+  expireTime timestamp(3) not NULL,
+  lockedTime timestamp(3) not NULL,
+  instanceId  varchar(255) not NULL,
+  PRIMARY KEY (serviceName)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/alpha/alpha-server/src/main/resources/schema-postgresql.sql
+++ b/alpha/alpha-server/src/main/resources/schema-postgresql.sql
@@ -115,3 +115,13 @@ CREATE TABLE IF NOT EXISTS tcc_tx_event (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS tcc_tx_event_index ON tcc_tx_event (globalTxId, localTxId, parentTxId, txType);
+
+CREATE TABLE IF NOT EXISTS master_lock (
+  serviceName varchar(36) not NULL,
+  expireTime timestamp(3) not NULL,
+  lockedTime timestamp(3) not NULL,
+  instanceId  varchar(255) not NULL,
+  PRIMARY KEY (serviceName)
+);
+
+CREATE INDEX IF NOT EXISTS master_lock_index ON master_lock (serviceName);

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
@@ -44,14 +44,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import javax.annotation.PostConstruct;
-import org.apache.servicecomb.pack.alpha.core.CommandRepository;
-import org.apache.servicecomb.pack.alpha.core.EventScanner;
-import org.apache.servicecomb.pack.alpha.core.OmegaCallback;
-import org.apache.servicecomb.pack.alpha.core.TxConsistentService;
-import org.apache.servicecomb.pack.alpha.core.TxEvent;
-import org.apache.servicecomb.pack.alpha.core.TxEventRepository;
-import org.apache.servicecomb.pack.alpha.core.TxTimeout;
-import org.apache.servicecomb.pack.alpha.core.TxTimeoutRepository;
+
+import org.apache.servicecomb.pack.alpha.core.*;
 import org.apache.servicecomb.pack.common.EventType;
 import org.apache.servicecomb.pack.contract.grpc.GrpcAck;
 import org.apache.servicecomb.pack.contract.grpc.GrpcCompensateCommand;
@@ -602,6 +596,6 @@ public class AlphaIntegrationTest {
         eventRepository,
         commandRepository,
         timeoutRepository,
-        omegaCallback, 1).run();
+        omegaCallback, 1, new NodeStatus(NodeStatus.TypeEnum.MASTER)).run();
   }
 }

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
@@ -63,7 +63,8 @@ public class ClusterLockServiceTest {
     private MasterLockRepository masterLockRepository;
 
     @Test(timeout = 5000)
-    public void testIsMaster() throws InterruptedException {
+    public void testClusterNodeType() throws InterruptedException {
+        //node type is master
         clusterLockService.setMasterLock(null);
         MasterLock masterLock = clusterLockService.getMasterLock();
         when(masterLockRepository.initLock(masterLock)).thenReturn(true);
@@ -74,12 +75,10 @@ public class ClusterLockServiceTest {
         }
         Assert.assertEquals(clusterLockService.isMasterNode(), true);
         clusterLockService.unLock();
-    }
 
-    @Test(timeout = 5000)
-    public void testIsSlave() throws InterruptedException {
+        //node type is slave
         clusterLockService.setMasterLock(null);
-        MasterLock masterLock = clusterLockService.getMasterLock();
+        masterLock = clusterLockService.getMasterLock();
         when(masterLockRepository.initLock(masterLock)).thenReturn(false);
         when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
         when(masterLockRepository.updateLock(masterLock)).thenReturn(false);

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
@@ -67,6 +67,9 @@ public class ClusterLockServiceTest {
         //node type is master
         clusterLockService.setMasterLock(null);
         MasterLock masterLock = clusterLockService.getMasterLock();
+        Assert.assertEquals(masterLock.getServiceName(),serviceName);
+        Assert.assertEquals(masterLock.getInstanceId(),instanceId);
+        Assert.assertEquals((masterLock.getExpireTime().getTime()-masterLock.getLockedTime().getTime()),expire);
         when(masterLockRepository.initLock(masterLock)).thenReturn(true);
         when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
         when(masterLockRepository.updateLock(masterLock)).thenReturn(true);

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.server.cluster.master;
+
+import org.apache.servicecomb.pack.alpha.server.AlphaApplication;
+import org.apache.servicecomb.pack.alpha.server.AlphaConfig;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
+import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLockRepository;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+@SpringBootTest(classes = {AlphaApplication.class, AlphaConfig.class},
+        properties = {
+                "alpha.cluster.master.enabled=true",
+                "alpha.server.host=0.0.0.0",
+                "alpha.server.port=8090",
+                "alpha.event.pollingInterval=1",
+                "spring.main.allow-bean-definition-overriding=true"
+        })
+public class ClusterLockServiceTest {
+
+    @Value("[${alpha.server.host}]:${alpha.server.port}")
+    private String instanceId;
+
+    @Value("${spring.application.name:servicecomb-alpha-server}")
+    private String serviceName;
+
+    @Value("${alpha.cluster.master.expire:5000}")
+    private int expire;
+
+    @Autowired
+    ClusterLockService clusterLockService;
+
+    @MockBean
+    private MasterLockRepository masterLockRepository;
+
+    @Test(timeout = 5000)
+    public void testIsMaster() throws InterruptedException {
+        clusterLockService.setMasterLock(null);
+        MasterLock masterLock = clusterLockService.getMasterLock();
+        when(masterLockRepository.initLock(masterLock)).thenReturn(true);
+        when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
+        when(masterLockRepository.updateLock(masterLock)).thenReturn(true);
+        while(!clusterLockService.isLockExecuted()) {
+            Thread.sleep(50);
+        }
+        Assert.assertEquals(clusterLockService.isMasterNode(), true);
+        clusterLockService.unLock();
+    }
+
+    @Test(timeout = 5000)
+    public void testIsSlave() throws InterruptedException {
+        clusterLockService.setMasterLock(null);
+        MasterLock masterLock = clusterLockService.getMasterLock();
+        when(masterLockRepository.initLock(masterLock)).thenReturn(false);
+        when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
+        when(masterLockRepository.updateLock(masterLock)).thenReturn(false);
+        while(!clusterLockService.isLockExecuted()) {
+            Thread.sleep(50);
+        }
+        Assert.assertEquals(clusterLockService.isMasterNode(), false);
+        clusterLockService.unLock();
+    }
+}


### PR DESCRIPTION
Dynamically configure the master node base on master_lock table

Configure `alpha.cluster.master.enabled=true` to activate this feature

### Attention
* mysql need configure `serverTimezone=GMT%2b8`
* need configure NTP

### example
Start two nodes
You can see the `Master Node` or `Slave Node` in the log. When the Master Node shutdown, Slave Node change to the Master Node.

```
java -jar alpha-server-0.4.0-SNAPSHOT-exec.jar \
  --server.port=0 \
  --alpha.server.port=8080 \
  --spring.datasource.url="jdbc:postgresql://127.0.0.1:5432/saga?useSSL=false" \
  --spring.datasource.username=saga-user \
  --spring.datasource.password=saga-password \
  --alpha.cluster.master.enabled=true
```

```
java -jar alpha-server-0.4.0-SNAPSHOT-exec.jar \
  --server.port=0 \
  --alpha.server.port=8081 \
  --spring.datasource.url="jdbc:postgresql://127.0.0.1:5432/saga?useSSL=false" \
  --spring.datasource.username=saga-user \
  --spring.datasource.password=saga-password \
  --alpha.cluster.master.enabled=true
```