### PR TITLE
[SCB-1152] Fixed test case logic to determine defects

### DIFF
--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
@@ -414,7 +414,9 @@ public class AlphaIntegrationTest {
 
     await().atMost(2, SECONDS).until(() -> {
       List<TxEvent> events = eventRepo.findByGlobalTxId(globalTxId);
-      return eventRepo.count() == 5 && events.get(events.size() - 1).type().equals(SagaEndedEvent.name());
+      return eventRepo.count() == 5 &&
+              events.get(events.size() - 1).type().equals(SagaEndedEvent.name()) &&
+              !events.get(events.size() - 2).type().equals(SagaEndedEvent.name());
     });
 
     List<TxEvent> events = eventRepo.findByGlobalTxId(globalTxId);


### PR DESCRIPTION
class AlphaIntegrationTest method abortTimeoutTxStartedEvent defects

```
    await().atMost(2, SECONDS).until(() -> {
      List<TxEvent> events = eventRepo.findByGlobalTxId(globalTxId);
      return eventRepo.count() == 5 && events.get(events.size() - 1).type().equals(SagaEndedEvent.name());
    });
```

Sometimes although eventRepo.count()==5 but there events list of results as follows

```
SagaStartedEvent
TxStartedEvent
TxAbortedEvent
SagaEndedEvent
SagaEndedEvent
```

compensation has not yet executed a cycle (method deleteDuplicateSagaEndedEvents() has not been executed yet), TxCompensatedEvent has not been added yet, but the condition eventRepo.count()==5 is met, so I changed to the following

```
    await().atMost(2, SECONDS).until(() -> {
      List<TxEvent> events = eventRepo.findByGlobalTxId(globalTxId);
      return eventRepo.count() == 5 && events.get(events.size() - 1).type().equals(SagaEndedEvent.name()) && !events.get(events.size() - 2).type().equals(SagaEndedEvent.name());
    });
```