### PR TITLE
[SCB-1158] Modify `ZIP` layout in maven plugin configuration support external jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Now we have different lanaguage implementation of Omega
    ```bash
       $ mvn clean install -DskipTests=true -Pdemo,docker
    ```     
-* Current ServiceComb Pack code supports Spring Boot 1.x and Spring Boot 2.x at the same time, saga uses Spring Boot 1.x by default, you can use *-Pspring-boot-2* to switch Spring Boot version to 2.x.
-Since Spring Boot supports JDK9 since 2.x, if you want to build and run test the Saga with JDK9 or JDK10, you need to use the spring-boot-2 profile. 
+* Current ServiceComb Pack code supports Spring Boot 1.x and Spring Boot 2.x at the same time, saga uses Spring Boot 2.x by default, you can use *-Pspring-boot-1* to switch Spring Boot version to 2.x.
+Since Spring Boot supports JDK9 since 2.x, if you want to build and run test the Saga with JDK9 or JDK10, please don't use the spring-boot-1 profile. 
    ```bash
-      $ mvn clean install -Pdemo,docker,spring-boot-2
+      $ mvn clean install -Pdemo,docker,spring-boot-1
    ```   
 
 ## User Guide

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,11 +48,11 @@ ServiceComb Pack 架构是由 **alpha** 和 **omega**组成，其中：
    ```bash
       $ mvn clean install -DskipTests=true -Pdemo,docker
    ```       
-* 当前ServiceComb Pack同时支持Spring Boot 1.x以及Spring Boot 2.x，在缺省情况下ServiceComb Pack会使用Spring Boot 1.x来进行构建。
-你可以使用 *-Pspring-boot-2* 将Spring Boot版本转换到 2.x 上。 由于Spring Boot 只在2.x开始支持 JDK9，如果你想用
-JDK9或者JDK10来编译Saga并运行测试的话，你需要使用spring-boot-2 profile参数。
+* 当前ServiceComb Pack同时支持Spring Boot 1.x以及Spring Boot 2.x，在缺省情况下ServiceComb Pack会使用Spring Boot 2.x来进行构建。
+你可以使用 *-Pspring-boot-1* 将Spring Boot版本转换到 1.x 上。 由于Spring Boot 只在2.x开始支持 JDK9，如果你想用
+JDK9或者JDK10来编译Saga并运行测试的话，请不要使用spring-boot-1 profile参数。
    ```bash
-      $ mvn clean install -Pdemo,docker,spring-boot-2
+      $ mvn clean install -Pdemo,docker,spring-boot-1
    ```
 
 ## 用户指南

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>acceptance-tests</artifactId>
+    <groupId>org.apache.servicecomb.pack</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>acceptance-pack-cluster-spring</artifactId>
+  <name>Pack:Acceptance Tests::Cluster Spring</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-submit</artifactId>
+      <version>${byteman.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <!-- TODO using jdk argLine to get rid of the jaxb dependencies -->
+      <properties>
+        <jdk.argLine>--add-modules java.xml.bind</jdk.argLine>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+          <version>${javax.activation.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <file>
+          <exists>/var/run/docker.sock</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <showLogs>true</showLogs>
+              <images>
+                <image>
+                  <name>postgres</name>
+                  <alias>postgres</alias>
+                  <run>
+                    <env>
+                      <POSTGRES_DB>saga</POSTGRES_DB>
+                      <POSTGRES_USER>saga</POSTGRES_USER>
+                      <POSTGRES_PASSWORD>password</POSTGRES_PASSWORD>
+                    </env>
+                    <wait>
+                      <log>database system is ready to accept connections</log>
+                      <tcp>
+                        <ports>
+                          <port>5432</port>
+                        </ports>
+                      </tcp>
+                      <time>60000</time>
+                    </wait>
+                    <ports>
+                      <port>postgres.port:5432</port>
+                    </ports>
+                  </run>
+                </image>
+                <image>
+                  <name>alpha-server:${project.version}</name>
+                  <alias>alpha</alias>
+                  <run>
+                    <env>
+                      <JAVA_OPTS>
+                        -Dspring.profiles.active=prd,test
+                      </JAVA_OPTS>
+                    </env>
+                    <links>
+                      <link>postgres:postgresql.servicecomb.io</link>
+                    </links>
+                    <wait>
+                      <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
+                      <tcp>
+                        <ports>
+                          <port>8080</port>
+                          <port>8090</port>
+                        </ports>
+                      </tcp>
+                      <time>120000</time>
+                    </wait>
+                    <ports>
+                      <port>alpha.port:8080</port>
+                      <port>alpha.rest.port:8090</port>
+                    </ports>
+                    <dependsOn>
+                      <container>postgres</container>
+                    </dependsOn>
+                  </run>
+                </image>
+                <image>
+                  <name>car:${project.version}</name>
+                  <alias>car</alias>
+                  <run>
+                    <env>
+                      <JAVA_OPTS>
+                        -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
+                        -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
+                      </JAVA_OPTS>
+                    </env>
+                    <wait>
+                      <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
+                      <tcp>
+                        <ports>
+                          <port>8080</port>
+                          <port>9091</port>
+                        </ports>
+                      </tcp>
+                      <time>120000</time>
+                    </wait>
+                    <links>
+                      <link>alpha:alpha-server.servicecomb.io</link>
+                    </links>
+                    <ports>
+                      <port>car.port:8080</port>
+                      <port>car.byteman.port:9091</port>
+                    </ports>
+                    <dependsOn>
+                      <container>alpha</container>
+                    </dependsOn>
+                  </run>
+                </image>
+                <image>
+                  <name>hotel:${project.version}</name>
+                  <alias>hotel</alias>
+                  <run>
+                    <env>
+                      <JAVA_OPTS>
+                        -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
+                        -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
+                      </JAVA_OPTS>
+                    </env>
+                    <wait>
+                      <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
+                      <tcp>
+                        <ports>
+                          <port>8080</port>
+                          <port>9091</port>
+                        </ports>
+                      </tcp>
+                      <time>120000</time>
+                    </wait>
+                    <links>
+                      <link>alpha:alpha-server.servicecomb.io</link>
+                    </links>
+                    <ports>
+                      <port>hotel.port:8080</port>
+                      <port>hotel.byteman.port:9091</port>
+                    </ports>
+                    <dependsOn>
+                      <container>alpha</container>
+                    </dependsOn>
+                  </run>
+                </image>
+                <image>
+                  <name>booking:${project.version}</name>
+                  <alias>booking</alias>
+                  <run>
+                    <env>
+                      <JAVA_OPTS>
+                        -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
+                        -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
+                      </JAVA_OPTS>
+                    </env>
+                    <wait>
+                      <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
+                      <tcp>
+                        <ports>
+                          <port>8080</port>
+                          <port>9091</port>
+                        </ports>
+                      </tcp>
+                      <time>120000</time>
+                    </wait>
+                    <links>
+                      <link>alpha:alpha-server.servicecomb.io</link>
+                      <link>car:car.servicecomb.io</link>
+                      <link>hotel:hotel.servicecomb.io</link>
+                    </links>
+                    <ports>
+                      <port>booking.port:8080</port>
+                      <port>booking.byteman.port:9091</port>
+                    </ports>
+                    <dependsOn>
+                      <container>alpha</container>
+                    </dependsOn>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>gmaven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-default-properties</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <source>
+                    project.properties.setProperty('docker.hostname', 'localhost')
+                    log.info("Docker hostname is " + project.properties['docker.hostname'])
+                  </source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <alpha.cluster.address>
+                  http://${docker.hostname}:${alpha.port}
+                </alpha.cluster.address>
+                <alpha.rest.address>
+                  http://${docker.hostname}:${alpha.rest.port}
+                </alpha.rest.address>
+                <car.service.address>
+                  http://${docker.hostname}:${car.port}
+                </car.service.address>
+                <hotel.service.address>
+                  http://${docker.hostname}:${hotel.port}
+                </hotel.service.address>
+                <booking.service.address>
+                  http://${docker.hostname}:${booking.port}
+                </booking.service.address>
+                <spring.datasource.url>
+                  jdbc:postgresql://${docker.hostname}:${postgres.port}/saga?useSSL=false
+                </spring.datasource.url>
+                <byteman.address>
+                  ${docker.hostname}
+                </byteman.address>
+                <car.byteman.port>
+                  ${car.byteman.port}
+                </car.byteman.port>
+                <hotel.byteman.port>
+                  ${hotel.byteman.port}
+                </hotel.byteman.port>
+                <booking.byteman.port>
+                  ${booking.byteman.port}
+                </booking.byteman.port>
+                <info.service.uri>
+                  ${info.service.uri}
+                </info.service.uri>
+              </systemPropertyVariables>
+              <argLine>${jacoco.failsafe.argLine}</argLine>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.ethlo.persistence.tools</groupId>
+            <artifactId>eclipselink-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>docker-machine</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>gmaven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-dynamic-properties</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <source>
+                    def process = "docker-machine ip default".execute()
+                    process.waitFor()
+                    project.properties.setProperty('docker.hostname', process.in.text.trim())
+
+                    log.info("Docker hostname is " + project.properties['docker.hostname'])
+                  </source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
@@ -120,12 +120,16 @@
                 </image>
                 <image>
                   <name>alpha-server:${project.version}</name>
-                  <alias>alpha</alias>
+                  <alias>alpha-1</alias>
                   <run>
                     <env>
                       <JAVA_OPTS>
                         -Dspring.profiles.active=prd,test
                       </JAVA_OPTS>
+                      <alpha.server.port>8080</alpha.server.port>
+                      <alpha.cluster.master.enabled>true</alpha.cluster.master.enabled>
+                      <management.endpoints.web.exposure.include>*</management.endpoints.web.exposure.include>
+                      <management.endpoint.shutdown.enabled>true</management.endpoint.shutdown.enabled>
                     </env>
                     <links>
                       <link>postgres:postgresql.servicecomb.io</link>
@@ -141,8 +145,44 @@
                       <time>120000</time>
                     </wait>
                     <ports>
-                      <port>alpha.port:8080</port>
-                      <port>alpha.rest.port:8090</port>
+                      <port>alpha-1.port:8080</port>
+                      <port>alpha-1.rest.port:8090</port>
+                    </ports>
+                    <dependsOn>
+                      <container>postgres</container>
+                    </dependsOn>
+                  </run>
+                </image>
+                <image>
+                  <name>alpha-server:${project.version}</name>
+                  <alias>alpha-2</alias>
+                  <run>
+                    <env>
+                      <JAVA_OPTS>
+                         -Dspring.profiles.active=prd,test
+                      </JAVA_OPTS>
+                      <alpha.server.port>8081</alpha.server.port>
+                      <server.port>8091</server.port>
+                      <alpha.cluster.master.enabled>true</alpha.cluster.master.enabled>
+                      <management.endpoints.web.exposure.include>*</management.endpoints.web.exposure.include>
+                      <management.endpoint.shutdown.enabled>true</management.endpoint.shutdown.enabled>
+                    </env>
+                    <links>
+                      <link>postgres:postgresql.servicecomb.io</link>
+                    </links>
+                    <wait>
+                      <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
+                      <tcp>
+                        <ports>
+                          <port>8081</port>
+                          <port>8091</port>
+                        </ports>
+                      </tcp>
+                      <time>120000</time>
+                    </wait>
+                    <ports>
+                      <port>alpha-2.port:8081</port>
+                      <port>alpha-2.rest.port:8091</port>
                     </ports>
                     <dependsOn>
                       <container>postgres</container>
@@ -158,6 +198,7 @@
                         -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
                         -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
                       </JAVA_OPTS>
+                      <alpha.cluster.address>alpha-server-1.servicecomb.io:8080,alpha-server-2.servicecomb.io:8081</alpha.cluster.address>
                     </env>
                     <wait>
                       <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
@@ -170,14 +211,16 @@
                       <time>120000</time>
                     </wait>
                     <links>
-                      <link>alpha:alpha-server.servicecomb.io</link>
+                      <link>alpha-1:alpha-server-1.servicecomb.io</link>
+                      <link>alpha-2:alpha-server-2.servicecomb.io</link>
                     </links>
                     <ports>
                       <port>car.port:8080</port>
                       <port>car.byteman.port:9091</port>
                     </ports>
                     <dependsOn>
-                      <container>alpha</container>
+                      <container>alpha-1</container>
+                      <contriner>alpha-2</contriner>
                     </dependsOn>
                   </run>
                 </image>
@@ -190,6 +233,7 @@
                         -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
                         -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
                       </JAVA_OPTS>
+                      <alpha.cluster.address>alpha-server-1.servicecomb.io:8080,alpha-server-2.servicecomb.io:8081</alpha.cluster.address>
                     </env>
                     <wait>
                       <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
@@ -202,14 +246,16 @@
                       <time>120000</time>
                     </wait>
                     <links>
-                      <link>alpha:alpha-server.servicecomb.io</link>
+                      <link>alpha-1:alpha-server-1.servicecomb.io</link>
+                      <link>alpha-2:alpha-server-2.servicecomb.io</link>
                     </links>
                     <ports>
                       <port>hotel.port:8080</port>
                       <port>hotel.byteman.port:9091</port>
                     </ports>
                     <dependsOn>
-                      <container>alpha</container>
+                      <container>alpha-1</container>
+                      <container>alpha-2</container>
                     </dependsOn>
                   </run>
                 </image>
@@ -222,6 +268,8 @@
                         -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
                         -javaagent:/maven/saga/byteman.jar=port:9091,address:0.0.0.0,listener:true
                       </JAVA_OPTS>
+                      <alpha.cluster.address>alpha-server-1.servicecomb.io:8080,alpha-server-2.servicecomb.io:8081</alpha.cluster.address>
+                      <alpha.rest.address>http://alpha-server-1.servicecomb.io:8090,http://alpha-server-2.servicecomb.io:8091</alpha.rest.address>
                     </env>
                     <wait>
                       <log>Started [a-zA-Z]+ in [0-9.]+ seconds</log>
@@ -234,7 +282,8 @@
                       <time>120000</time>
                     </wait>
                     <links>
-                      <link>alpha:alpha-server.servicecomb.io</link>
+                      <link>alpha-1:alpha-server-1.servicecomb.io</link>
+                      <link>alpha-2:alpha-server-2.servicecomb.io</link>
                       <link>car:car.servicecomb.io</link>
                       <link>hotel:hotel.servicecomb.io</link>
                     </links>
@@ -243,7 +292,8 @@
                       <port>booking.byteman.port:9091</port>
                     </ports>
                     <dependsOn>
-                      <container>alpha</container>
+                      <container>alpha-1</container>
+                      <container>alpha-2</container>
                     </dependsOn>
                   </run>
                 </image>
@@ -292,10 +342,10 @@
             <configuration>
               <systemPropertyVariables>
                 <alpha.cluster.address>
-                  http://${docker.hostname}:${alpha.port}
+                  http://${docker.hostname}:${alpha-1.port}
                 </alpha.cluster.address>
                 <alpha.rest.address>
-                  http://${docker.hostname}:${alpha.rest.port}
+                  http://${docker.hostname}:${alpha-1.rest.port},http://${docker.hostname}:${alpha-2.rest.port}
                 </alpha.rest.address>
                 <car.service.address>
                   http://${docker.hostname}:${car.port}

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/java/org/apache/servicecomb/pack/PackStepdefs.java
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/java/org/apache/servicecomb/pack/PackStepdefs.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack;
+
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.Is.is;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jboss.byteman.agent.submit.Submit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.restassured.response.Response;
+import cucumber.api.DataTable;
+import cucumber.api.java.After;
+import cucumber.api.java8.En;
+
+public class PackStepdefs implements En {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String ALPHA_REST_ADDRESS = "alpha.rest.address";
+  private static final String CAR_SERVICE_ADDRESS = "car.service.address";
+  private static final String HOTEL_SERVICE_ADDRESS = "hotel.service.address";
+  private static final String BOOKING_SERVICE_ADDRESS = "booking.service.address";
+  private static final String INFO_SERVICE_URI = "info.service.uri";
+  private static final String[] addresses = {CAR_SERVICE_ADDRESS, HOTEL_SERVICE_ADDRESS};
+
+  private static final Consumer<Map<String, String>[]> NO_OP_CONSUMER = (dataMap) -> {
+  };
+
+  private static final Map<String, Submit> submits = new HashMap<>();
+
+  public PackStepdefs() {
+    Given("^Car Service is up and running$", () -> {
+      probe(System.getProperty(CAR_SERVICE_ADDRESS));
+    });
+
+    And("^Hotel Service is up and running$", () -> {
+      probe(System.getProperty(HOTEL_SERVICE_ADDRESS));
+    });
+
+    And("^Booking Service is up and running$", () -> {
+      probe(System.getProperty(BOOKING_SERVICE_ADDRESS));
+    });
+
+    And("^Alpha is up and running$", () -> {
+      probe(System.getProperty(ALPHA_REST_ADDRESS));
+    });
+
+    Given("^Install the byteman script ([A-Za-z0-9_\\.]+) to ([A-Za-z]+) Service$", (String script, String service) -> {
+      LOG.info("Install the byteman script {} to {} service", script, service);
+      List<String> rules = new ArrayList<>();
+      rules.add("target/test-classes/" + script);
+      Submit bm = getBytemanSubmit(service);
+      bm.addRulesFromFiles(rules);
+    });
+
+    When("^User ([A-Za-z]+) requests to book ([0-9]+) cars and ([0-9]+) rooms (success|fail)$", (username, cars, rooms, result) -> {
+      LOG.info("Received request from user {} to book {} cars and {} rooms", username, cars, rooms);
+
+      Response resp = given()
+          .pathParam("name", username)
+          .pathParam("rooms", rooms)
+          .pathParam("cars", cars)
+          .when()
+          .post(System.getProperty("booking.service.address") + "/booking/{name}/{rooms}/{cars}");
+      if (result.equals("success")) {
+        resp.then().statusCode(is(200));
+      } else if (result.equals("fail")) {
+        resp.then().statusCode(is(500));
+      }
+    });
+
+    Then("^Alpha records the following events$", (DataTable dataTable) -> {
+      Consumer<Map<String, String>[]> columnStrippingConsumer = dataMap -> {
+        for (Map<String, String> map : dataMap)
+          map.keySet().retainAll(dataTable.topCells());
+      };
+
+      dataMatches(System.getProperty(ALPHA_REST_ADDRESS) + "/saga/events", dataTable, columnStrippingConsumer);
+    });
+
+    And("^Car Service contains the following booking orders$", (DataTable dataTable) -> {
+      dataMatches(System.getProperty(CAR_SERVICE_ADDRESS) + "/bookings", dataTable, NO_OP_CONSUMER);
+    });
+
+    And("^Hotel Service contains the following booking orders$", (DataTable dataTable) -> {
+      dataMatches(System.getProperty(HOTEL_SERVICE_ADDRESS) + "/bookings", dataTable, NO_OP_CONSUMER);
+    });
+  }
+
+  @After
+  public void cleanUp() {
+    LOG.info("Cleaning up services");
+    for (String address : addresses) {
+      given()
+          .when()
+          .delete(System.getProperty(address) + "/bookings")
+          .then()
+          .statusCode(is(200));
+    }
+
+    given()
+        .when()
+        .delete(System.getProperty(ALPHA_REST_ADDRESS) + "/saga/events")
+        .then()
+        .statusCode(is(200));
+
+    for (Submit bm : submits.values()) {
+      try {
+        bm.deleteAllRules();
+      } catch (Exception e) {
+        LOG.warn("Fail to delete the byteman rules " + e);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void dataMatches(String address, DataTable dataTable, Consumer<Map<String, String>[]> dataProcessor) {
+    List<Map<String, String>> expectedMaps = dataTable.asMaps(String.class, String.class);
+    List<Map<String, String>> actualMaps = new ArrayList<>();
+
+    await().atMost(5, SECONDS).until(() -> {
+      actualMaps.clear();
+      Collections.addAll(actualMaps, retrieveDataMaps(address, dataProcessor));
+      // write the log if the Map size is not same
+      boolean result = expectedMaps.size() == actualMaps.size();
+      if (!result) {
+        LOG.warn("The response message size is not we expected. ExpectedMap size is {},  ActualMap size is {}", expectedMaps.size(), actualMaps.size());
+      }
+      return expectedMaps.size() == actualMaps.size();
+    });
+
+    if (expectedMaps.isEmpty() && actualMaps.isEmpty()) {
+      return;
+    }
+
+    LOG.info("Retrieved data {} from service", actualMaps);
+    dataTable.diff(DataTable.create(actualMaps));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, String>[] retrieveDataMaps(String address, Consumer<Map<String, String>[]> dataProcessor) {
+    Map<String, String>[] dataMap = given()
+        .when()
+        .get(address)
+        .then()
+        .statusCode(is(200))
+        .extract()
+        .body()
+        .as(Map[].class);
+
+    dataProcessor.accept(dataMap);
+    return dataMap;
+  }
+
+  private void probe(String address) {
+    String infoURI = System.getProperty(INFO_SERVICE_URI);
+    if (isEmpty(infoURI)) {
+      infoURI = "/info";
+    }
+    LOG.info("The info service uri is " + infoURI);
+    probe(address, infoURI);
+  }
+
+  private void probe(String address, String infoURI) {
+    LOG.info("Connecting to service address {}", address);
+    given()
+        .when()
+        .get(address + infoURI)
+        .then()
+        .statusCode(is(200));
+  }
+
+  private Submit getBytemanSubmit(String service) {
+    if (submits.containsKey(service)) {
+      return submits.get(service);
+    } else {
+      String address = System.getProperty("byteman.address");
+      String port = System.getProperty(service.toLowerCase() + ".byteman.port");
+      Submit bm = new Submit(address, Integer.parseInt(port));
+      submits.put(service, bm);
+      return bm;
+    }
+  }
+}

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/java/org/apache/servicecomb/pack/RunCucumberIT.java
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/java/org/apache/servicecomb/pack/RunCucumberIT.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(plugin = {"pretty", "html:target/cucumber"},
+    features = "src/test/resources")
+public class RunCucumberIT {
+}

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/alpha_shutdown.btm
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/alpha_shutdown.btm
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# rules to shutdown alpha server master node  the booking after invoking the services
+#
+###############################################################
+
+RULE alpha master shutdown
+CLASS org.apache.servicecomb.pack.demo.booking.BookingController
+METHOD postCarBooking
+AT ENTRY
+IF TRUE
+DO $this.alphaMasterShutdown(),
+    Thread.sleep(5000)
+ENDRULE

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/booking_exception.btm
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/booking_exception.btm
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# rules to timeout the booking after invoking the services
+#
+###############################################################
+
+RULE throw exception
+CLASS org.apache.servicecomb.pack.demo.booking.BookingController
+METHOD postCarBooking
+AT ENTRY
+IF TRUE
+DO debug("throw RuntimeException here"),
+   throw new RuntimeException("Cannot access the booking hotel server!")
+ENDRULE

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/booking_timeout.btm
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/booking_timeout.btm
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# rules to timeout the booking after invoking the services
+#
+###############################################################
+
+RULE set the saga timeout to 5s
+INTERFACE org.apache.servicecomb.pack.omega.context.annotations.SagaStart
+METHOD timeout
+AT EXIT
+IF TRUE
+DO RETURN 5
+ENDRULE
+
+RULE sleep when postBooking until timeout happens
+CLASS org.apache.servicecomb.pack.demo.booking.BookingController
+METHOD postBooking
+AT ENTRY
+IF TRUE
+DO debug("delay 10s until the booking timeout"),
+   Thread.sleep(10000)
+ENDRULE

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/log4j2-test.xml
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/log4j2-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_compensation_scenario.feature
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_compensation_scenario.feature
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Alpha records transaction events
+
+  Scenario: A sub-transaction failed and global transaction compensated
+    Given Car Service is up and running
+    And Hotel Service is up and running
+    And Booking Service is up and running
+    And Alpha is up and running
+
+    When User Sean requests to book 5 cars and 3 rooms fail
+
+    Then Alpha records the following events
+      | serviceName  | type               |
+      | booking | SagaStartedEvent   |
+      | car     | TxStartedEvent     |
+      | car     | TxEndedEvent       |
+      | hotel   | TxStartedEvent     |
+      | hotel   | TxAbortedEvent     |
+      | booking | TxAbortedEvent     |
+      | car     | TxCompensatedEvent |
+      | car     | SagaEndedEvent     |
+    
+    Then Car Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 5      | false     | true      |
+
+    Then Hotel Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_post_car_exception_scenario.feature
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_post_car_exception_scenario.feature
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Alpha records transaction events
+
+  Scenario: An exception is throw and the first transaction should be compensated
+    Given Car Service is up and running
+    And Hotel Service is up and running
+    And Booking Service is up and running
+    And Alpha is up and running
+
+    Given Install the byteman script booking_exception.btm to Booking Service
+
+    When User Sean requests to book 1 cars and 1 rooms fail
+
+    Then Alpha records the following events
+      | serviceName  | type               |
+      | booking | SagaStartedEvent   |
+      | car     | TxStartedEvent     |
+      | car     | TxEndedEvent       |
+      | booking | TxAbortedEvent     |
+      | car     | TxCompensatedEvent |
+      | car     | SagaEndedEvent     |
+
+    Then Car Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 1      | false     | true      |
+
+    Then Hotel Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+    

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_success_scenario.feature
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_success_scenario.feature
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Alpha records transaction events
+
+  Scenario: Everything is normal
+    Given Car Service is up and running
+    And Hotel Service is up and running
+    And Booking Service is up and running
+    And Alpha is up and running
+
+    When User Sean requests to book 2 cars and 1 rooms success
+
+    Then Alpha records the following events
+      | serviceName  | type             |
+      | booking | SagaStartedEvent |
+      | car     | TxStartedEvent   |
+      | car     | TxEndedEvent     |
+      | hotel   | TxStartedEvent   |
+      | hotel   | TxEndedEvent     |
+      | booking | SagaEndedEvent   |
+
+    And Car Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 2      | true      | false     |
+
+    And Hotel Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 1      | true      | false     |

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_success_scenario.feature
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_success_scenario.feature
@@ -19,7 +19,9 @@ Feature: Alpha records transaction events
     Given Car Service is up and running
     And Hotel Service is up and running
     And Booking Service is up and running
-    And Alpha is up and running
+    And Alpha cluster is up and running
+
+    Given Install the byteman script alpha_shutdown.btm to Booking Service
 
     When User Sean requests to book 2 cars and 1 rooms success
 

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_timeout_scenario.feature
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/src/test/resources/pack_timeout_scenario.feature
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Alpha records transaction events
+
+  Scenario: A transaction timeout and will be compensated
+    Given Car Service is up and running
+    And Hotel Service is up and running
+    And Booking Service is up and running
+    And Alpha is up and running
+
+    Given Install the byteman script booking_timeout.btm to Booking Service
+
+    When User Sean requests to book 1 cars and 1 rooms fail
+
+    Then Alpha records the following events
+      | serviceName  | type          |
+      | booking | SagaStartedEvent   |
+      | car     | TxStartedEvent     |
+      | car     | TxEndedEvent       |
+      | hotel   | TxStartedEvent     |
+      | hotel   | TxEndedEvent       |
+      | booking | TxAbortedEvent     |
+      | hotel   | TxCompensatedEvent |
+      | car     | TxCompensatedEvent |
+      | car     | SagaEndedEvent   |
+
+
+    Then Car Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 1      | false     | true      |
+
+    Then Hotel Service contains the following booking orders
+      | id | name | amount | confirmed | cancelled |
+      | 1  | Sean | 1      | false     | true      |
+

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -33,6 +33,7 @@
     <module>acceptance-pack-dubbo-demo</module>
     <module>acceptance-pack-spring-demo</module>
     <module>acceptance-pack-tcc-spring-demo</module>
+    <module>acceptance-pack-cluster-spring-demo</module>
   </modules>
 
   <properties>

--- a/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/actuate/endpoint/AlphaStatus.java
+++ b/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/actuate/endpoint/AlphaStatus.java
@@ -1,0 +1,15 @@
+package org.apache.servicecomb.pack.alpha.core.actuate.endpoint;
+
+import org.apache.servicecomb.pack.alpha.core.NodeStatus;
+
+public class AlphaStatus {
+  private NodeStatus.TypeEnum nodeType;
+
+  public NodeStatus.TypeEnum getNodeType() {
+    return nodeType;
+  }
+
+  public void setNodeType(NodeStatus.TypeEnum nodeType) {
+    this.nodeType = nodeType;
+  }
+}

--- a/alpha/alpha-server/pom.xml
+++ b/alpha/alpha-server/pom.xml
@@ -55,6 +55,11 @@
         <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         <version>${spring.cloud.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.servicecomb.pack</groupId>
+        <artifactId>alpha-spring-boot-starter</artifactId>
+        <version>${spring.boot.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -166,6 +171,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.servicecomb.pack</groupId>
+      <artifactId>alpha-spring-boot-starter</artifactId>
     </dependency>
   </dependencies>
 

--- a/alpha/alpha-server/pom.xml
+++ b/alpha/alpha-server/pom.xml
@@ -189,6 +189,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <layout>ZIP</layout>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.ethlo.persistence.tools</groupId>

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockService.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.pack.alpha.server.cluster.master;
 
 import org.apache.servicecomb.pack.alpha.core.NodeStatus;
+import org.apache.servicecomb.pack.alpha.server.AlphaConfig;
 import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.LockProvider;
 import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.Lock;
 import org.apache.servicecomb.pack.alpha.server.cluster.master.provider.jdbc.jpa.MasterLock;
@@ -25,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
@@ -54,6 +56,7 @@ import java.util.Optional;
 @Component
 @ConditionalOnProperty(name = "alpha.cluster.master.enabled", havingValue = "true")
 @EnableScheduling
+@AutoConfigureAfter(AlphaConfig.class)
 public class ClusterLockService implements ApplicationListener<ApplicationReadyEvent> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
@@ -67,13 +67,14 @@ public class ClusterLockServiceTest {
     //node type is master
     clusterLockService.setMasterLock(null);
     MasterLock masterLock = clusterLockService.getMasterLock();
-    Assert.assertEquals(masterLock.getServiceName(), serviceName);
-    Assert.assertEquals(masterLock.getInstanceId(), instanceId);
-    Assert.assertEquals((masterLock.getExpireTime().getTime() - masterLock.getLockedTime().getTime()), expire);
+    Assert.assertEquals(masterLock.getServiceName(),serviceName);
+    Assert.assertEquals(masterLock.getInstanceId(),instanceId);
+    Assert.assertEquals((masterLock.getExpireTime().getTime()-masterLock.getLockedTime().getTime()),expire);
     when(masterLockRepository.initLock(masterLock)).thenReturn(true);
     when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
     when(masterLockRepository.updateLock(masterLock)).thenReturn(true);
-    while (!clusterLockService.isLockExecuted()) {
+    Thread.sleep(1000);
+    while(!clusterLockService.isLockExecuted()) {
       Thread.sleep(50);
     }
     Assert.assertEquals(clusterLockService.isMasterNode(), true);
@@ -85,7 +86,8 @@ public class ClusterLockServiceTest {
     when(masterLockRepository.initLock(masterLock)).thenReturn(false);
     when(masterLockRepository.findMasterLockByServiceName(serviceName)).thenReturn(Optional.of(masterLock));
     when(masterLockRepository.updateLock(masterLock)).thenReturn(false);
-    while (!clusterLockService.isLockExecuted()) {
+    Thread.sleep(1000);
+    while(!clusterLockService.isLockExecuted()) {
       Thread.sleep(50);
     }
     Assert.assertEquals(clusterLockService.isMasterNode(), false);

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/cluster/master/ClusterLockServiceTest.java
@@ -62,7 +62,7 @@ public class ClusterLockServiceTest {
   @MockBean
   private MasterLockRepository masterLockRepository;
 
-  @Test(timeout = 5000)
+  @Test(timeout = 10000)
   public void testClusterNodeType() throws InterruptedException {
     //node type is master
     clusterLockService.setMasterLock(null);

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/pom.xml
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>alpha</artifactId>
+    <groupId>org.apache.servicecomb.pack</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>alpha-spring-boot-starter</artifactId>
+  <name>Pack::Alpha::Spring Boot 1.X Starter</name>
+  <version>1.5.17.RELEASE</version>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring.boot1.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+          </exclusion>
+        </exclusions>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot1.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        <version>${spring.cloud1.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.servicecomb.pack</groupId>
+      <artifactId>alpha-core</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter</artifactId>
+        <exclusions>
+            <exclusion>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-logging</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/ActuatorEndpoint.java
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/ActuatorEndpoint.java
@@ -1,0 +1,38 @@
+package org.apache.servicecomb.pack.alpha.server.actuate.endpoint;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ActuatorEndpoint implements Endpoint<List<Endpoint>> {
+
+  @Autowired
+  private List<Endpoint> endpoints;
+
+  @Override
+  public String getId() {
+    return "actuator";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isSensitive() {
+    return false;
+  }
+
+  @Override
+  public List<Endpoint> invoke() {
+    throw new UnsupportedOperationException();
+  }
+
+  public List<Endpoint> endpoints() {
+    return endpoints;
+  }
+}

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/AlphaEndpoint.java
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/AlphaEndpoint.java
@@ -1,0 +1,42 @@
+package org.apache.servicecomb.pack.alpha.server.actuate.endpoint;
+
+import org.apache.servicecomb.pack.alpha.core.NodeStatus;
+import org.apache.servicecomb.pack.alpha.core.actuate.endpoint.AlphaStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "endpoints.alpha")
+@Component
+public class AlphaEndpoint implements Endpoint {
+
+  public static final String END_POINT_ID = "alpha";
+
+  @Autowired
+  NodeStatus nodeStatus;
+
+  private AlphaStatus alphaStatus = new AlphaStatus();
+
+  @Override
+  public String getId() {
+    return END_POINT_ID;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isSensitive() {
+    return false;
+  }
+
+  @Override
+  public AlphaStatus invoke() {
+    alphaStatus.setNodeType(nodeStatus.getTypeEnum());
+    return alphaStatus;
+  }
+
+}

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/mvc/ActuatorMvcEndpoint.java
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-1-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/mvc/ActuatorMvcEndpoint.java
@@ -1,0 +1,48 @@
+package org.apache.servicecomb.pack.alpha.server.actuate.endpoint.mvc;
+
+import org.apache.servicecomb.pack.alpha.server.actuate.endpoint.ActuatorEndpoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static java.util.Optional.ofNullable;
+
+@Component
+public class ActuatorMvcEndpoint extends EndpointMvcAdapter {
+
+  private final ActuatorEndpoint delegate;
+
+  @Autowired
+  public ActuatorMvcEndpoint(ActuatorEndpoint delegate) {
+    super(delegate);
+    this.delegate = delegate;
+  }
+
+  @RequestMapping(value = "/{endpoint}", method = {RequestMethod.GET, RequestMethod.POST})
+  @ResponseBody
+  public Object endpoint(@PathVariable("endpoint") String id, @RequestParam(required = false) Boolean enabled,
+                         @RequestParam(required = false) Boolean sensitive) {
+    Predicate<Endpoint> isEnabled =
+            endpoint -> matches(endpoint::isEnabled, ofNullable(enabled));
+
+    Predicate<Endpoint> isSensitive =
+            endpoint -> matches(endpoint::isSensitive, ofNullable(sensitive));
+
+    Predicate<Endpoint> matchEndPoint =
+            endpoint -> matches(endpoint::getId, ofNullable(id));
+
+    return this.delegate.endpoints().stream()
+            .filter(matchEndPoint.and(isEnabled.and(isSensitive)))
+            .findAny().get().invoke();
+  }
+
+  private <T> boolean matches(Supplier<T> supplier, Optional<T> value) {
+    return !value.isPresent() || supplier.get().equals(value.get());
+  }
+}

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-2-starter/pom.xml
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-2-starter/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>alpha</artifactId>
+    <groupId>org.apache.servicecomb.pack</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>alpha-spring-boot-starter</artifactId>
+  <name>Pack::Alpha::Spring Boot 2.X Starter</name>
+  <version>2.1.1.RELEASE</version>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring.boot2.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+          </exclusion>
+        </exclusions>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        <version>${spring.cloud2.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.servicecomb.pack</groupId>
+      <artifactId>alpha-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-2-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/AlphaEndPoint.java
+++ b/alpha/alpha-spring-boot-compatibility/alpha-spring-boot-2-starter/src/main/java/org/apache/servicecomb/pack/alpha/server/actuate/endpoint/AlphaEndPoint.java
@@ -1,0 +1,27 @@
+package org.apache.servicecomb.pack.alpha.server.actuate.endpoint;
+
+import org.apache.servicecomb.pack.alpha.core.NodeStatus;
+import org.apache.servicecomb.pack.alpha.core.actuate.endpoint.AlphaStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+
+@Configuration
+@Endpoint(id = "alpha")
+public class AlphaEndPoint {
+
+  private AlphaStatus alphaStatus = new AlphaStatus();
+
+  @Autowired
+  @Lazy
+  private NodeStatus nodeStatus;
+
+  @ReadOperation
+  public AlphaStatus endpoint() {
+    alphaStatus.setNodeType(nodeStatus.getTypeEnum());
+    return alphaStatus;
+  }
+}

--- a/alpha/alpha-spring-boot-compatibility/pom.xml
+++ b/alpha/alpha-spring-boot-compatibility/pom.xml
@@ -26,27 +26,13 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>alpha</artifactId>
-  <name>Pack::Alpha</name>
+  <artifactId>alpha-spring-boot-compatibility</artifactId>
+  <name>Pack::Alpha Spring Boot Compatibility</name>
 
   <packaging>pom</packaging>
   <modules>
-    <module>alpha-core</module>
-    <module>alpha-spring-boot-compatibility</module>
-    <module>alpha-server</module>
+    <module>alpha-spring-boot-1-starter</module>
+    <module>alpha-spring-boot-2-starter</module>
   </modules>
-
-  <build>
-    <plugins>
-      <!-- TODO need to clean up the states of AlphaServer -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/docs/faq/cn/how_to_use_mysql_as_alpha_backend_database.md
+++ b/docs/faq/cn/how_to_use_mysql_as_alpha_backend_database.md
@@ -30,13 +30,15 @@
 4. 运行alpha。请确保MySQL在此前已成功启动。alpha的运行可通过docker或可执行文件的方式。
    * 通过docker
       ```bash
-      docker run -d -p 8080:8080 -p 8090:8090 -e "JAVA_OPTS=-Dspring.profiles.active=mysql -Dspring.datasource.url=jdbc:mysql://${host_address}:3306/saga?useSSL=false" alpha-server:${saga_version}
+      docker run -d -p 8080:8080 -p 8090:8090 -e "JAVA_OPTS=-Dspring.profiles.active=mysql -Dspring.datasource.url=jdbc:mysql://${host_address}:3306/saga?serverTimezone=GMT%2b8&useSSL=false" alpha-server:${saga_version}
       ```
    * 通过可执行文件
       ```bash
-      java -Dspring.profiles.active=mysql -D"spring.datasource.url=jdbc:mysql://${host_address}:3306/saga?useSSL=false" -jar alpha-server-${saga_version}-exec.jar
+      java -Dspring.profiles.active=mysql -D"spring.datasource.url=jdbc:mysql://${host_address}:3306/saga?serverTimezone=GMT%2b8&useSSL=false" -jar alpha-server-${saga_version}-exec.jar
       ```
    **注意**: 请在运行命令前将`${saga_version}`和`${host_address}`更改为实际值。
 
    **注意**: 默认情况下，8080端口用于处理omega处发起的gRPC的请求，而8090端口用于处理查询存储在alpha处的事件信息。
+   
+   **注意**: 请确保MySQL连接串中设置了正确的时区参数`serverTimezone=GMT%2b8`。
 

--- a/docs/faq/en/how_to_use_mysql_as_alpha_backend_database.md
+++ b/docs/faq/en/how_to_use_mysql_as_alpha_backend_database.md
@@ -41,3 +41,6 @@
 
 
    **Note**: By default, port 8080 is used to serve omega's request via gRPC while port 8090 is used to query the events stored in alpha.
+   
+   
+   **Note**: Please configuration serverTimezone property in MySQL connection string

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -208,7 +208,7 @@ Add TCC annotations and corresponding confirm and cancel methods
        address: {alpha.cluster.addresses}
    ```
 
-Then you can start your micro-services and access all saga events via http://${alpha-server:port}/events.
+Then you can start your micro-services and access all saga events via http://${alpha-server:port}/saga/events.
 
 ## Enable SSL for Alpha and Omega
 

--- a/docs/user_guide_zh.md
+++ b/docs/user_guide_zh.md
@@ -132,8 +132,8 @@ Saga可通过以下任一方式进行构建：
         SpringApplication.run(Application.class, args);
       }
     }
-    ```
-    
+   ```
+   
 2. 在全局事务的起点添加 `@TccStart` 的注解。
     ```java
     import org.apache.servicecomb.pack.omega.context.annotations.TccStart;
@@ -145,12 +145,12 @@ Saga可通过以下任一方式进行构建：
     }
     ```
     **Note:** 当前TCC还不支持Timeout
- 
+
 3. 在子事务尝试方法处添加 `@Participate` 的注解并指明其对应的执行以及补偿方法名, 
     ```java
     import javax.transaction.Transactional;
     import org.apache.servicecomb.pack.omega.transaction.annotations.Participate;
-   
+      
     @Participate(confirmMethod = "confirm", cancelMethod = "cancel")
     @Transactional
     public void transferOut(String from, int amount) {
@@ -161,17 +161,17 @@ Saga可通过以下任一方式进行构建：
     public void confirm(String from, int amount) {
       repo.reduceBalanceByUsername(from, amount);
     }
-  
+    
     @Transactional
     public void cancel(String from, int amount) {
       repo.addBalanceByUsername(from, amount);
     }
     ```
- 
+
     **Note:** The confirm and cancel method should have same arguments with participate method, confirm and cancel method implemented by services must be idempotent. We highly recommend to use the Spring @Transactional to guarantee the local transaction.
    
     **Note:** 若全局事务起点与子事务起点重合，需同时声明 `@TccStart`  和 `@Participate` 的注解。 
- 
+
 4. 对转入服务重复第三步即可。
 
 5. 从pack-0.3.0开始, 你可以在服务函数或者取消函数中通过访问 [OmegaContext](https://github.com/apache/servicecomb-pack/blob/master/omega/omega-context/src/main/java/org/apache/servicecomb/saga/omega/context/OmegaContext.java) 来获取 gloableTxId 以及 localTxId 信息。
@@ -211,4 +211,4 @@ Saga可通过以下任一方式进行构建：
        address: {alpha.cluster.addresses}
    ```
 
-然后就可以运行相关的微服务了，可通过访问http://${alpha-server:port}/events 来获取所有的saga事件信息。
+然后就可以运行相关的微服务了，可通过访问http://${alpha-server:port}/saga/events 来获取所有的saga事件信息。

--- a/docs/user_guide_zh.md
+++ b/docs/user_guide_zh.md
@@ -268,7 +268,7 @@ Saga可通过以下任一方式进行构建：
    </applications>
    ```
 
-   **注意:** 默认情况下注册的服务名是`SERVICECOMB-ALPHA-SERVER`,如果你需要自定义服务名可以在运行Alpha的时候通过命令行参数`spring.application.name=XXX`指定
+   **注意:** 默认情况下注册的服务名是`SERVICECOMB-ALPHA-SERVER`,如果你需要自定义服务名可以在运行Alpha的时候通过命令行参数`spring.application.name`配置
 
 4. 配置omega
 
@@ -293,10 +293,10 @@ Saga可通过以下任一方式进行构建：
      cluster:
        register:
          type: spring-cloud
-   omega:
-     instance:
-       instanceId: ${spring.application.name}-${spring.cloud.client.hostname}-${server.port}
    ```
+
+   * `eureka.client.service-url.defaultZone` 配置Eureka注册中心的地址，其他Eureka客户端配置可以参考[Spring Cloud Netflix 2.x](https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html#netflix-eureka-client-starter) 或 [Spring Cloud Netflix 1.x](https://cloud.spring.io/spring-cloud-netflix/1.4.x/multi/multi__service_discovery_eureka_clients.html#netflix-eureka-client-starter)
+   * `alpha.cluster.register.type=spring-cloud` 配置Omega获取Alpha的方式是通过Eureka的注册中心
 
    **注意:** 如果你在启动Alpha的时候通过命令行参数`spring.application.name`自定义了服务名，那么那么你需要在Omega中通过参数`alpha.cluster.serviceId`指定这个服务名
 

--- a/docs/user_guide_zh.md
+++ b/docs/user_guide_zh.md
@@ -285,6 +285,10 @@ Saga可通过以下任一方式进行构建：
    在 `application.yaml` 添加下面的配置项：
 
    ```yaml
+   eureka:
+     client:
+       service-url:
+         defaultZone: http://127.0.0.1:8761/eureka
    alpha:
      cluster:
        register:

--- a/docs/user_guide_zh.md
+++ b/docs/user_guide_zh.md
@@ -233,7 +233,7 @@ Saga可通过以下任一方式进行构建：
 
    
 
-2. 运行Alpha
+2. 运行alpha
 
    运行是增加`spring.profiles.active=spring-cloud-eureka`参数
 
@@ -268,6 +268,8 @@ Saga可通过以下任一方式进行构建：
    </applications>
    ```
 
+   **注意:** 默认情况下注册的服务名是`SERVICECOMB-ALPHA-SERVER`,如果你需要自定义服务名可以在运行Alpha的时候通过命令行参数`spring.application.name=XXX`指定
+
 4. 配置omega
 
    在项目中引入依赖包`omega-spring-cloud-starter`
@@ -292,5 +294,5 @@ Saga可通过以下任一方式进行构建：
        instanceId: ${spring.application.name}-${spring.cloud.client.hostname}-${server.port}
    ```
 
-   
+   **注意:** 如果你在启动Alpha的时候通过命令行参数`spring.application.name`自定义了服务名，那么那么你需要在Omega中通过参数`alpha.cluster.serviceId`指定这个服务名
 


### PR DESCRIPTION
We can use loads external jars support multiple database types
create libs directory in the alpha-server-0.4.0-SNAPSHOT-exec.jar directory, copy mysql-connector-java-8.0.15.jar to the libs directory And add config -Dloader.path=./libs to the command line, e.g.

```shell
java -Dloader.path=./libs -jar alpha-server-0.4.0-SNAPSHOT-exec.jar \
--spring.datasource.platform=mysql \
--spring.datasource.dataSourceClassName=com.mysql.jdbc.Driver \
--spring.datasource.url='jdbc:mysql://0.0.0.0:3306/saga?useUnicode=true&characterEncoding=utf-8&autoReconnect=true' \
--spring.datasource.username=saga-user \
--spring.datasource.password=saga-password \
--spring.profiles.active=prd
```

In order to external jars support need to modify alpha-server pom.xml use `ZIP` layout in maven plugin configuration, e.g

```
<plugin>
<groupId>org.springframework.boot</groupId>
<artifactId>spring-boot-maven-plugin</artifactId>
<configuration>
  <layout>ZIP</layout>
</configuration>
</plugin>
```