### PR TITLE
fix mysql master_lock table schema wrong default value

### DIFF
--- a/alpha/alpha-server/src/main/resources/schema-mysql.sql
+++ b/alpha/alpha-server/src/main/resources/schema-mysql.sql
@@ -116,8 +116,8 @@ CREATE TABLE IF NOT EXISTS tcc_tx_event (
 
 CREATE TABLE IF NOT EXISTS master_lock (
   serviceName varchar(36) not NULL,
-  expireTime timestamp(3) not NULL,
-  lockedTime timestamp(3) not NULL,
+  expireTime datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  lockedTime datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   instanceId  varchar(255) not NULL,
   PRIMARY KEY (serviceName)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
The Mysql table schema in schema-mysql.sql has some problem.

I try to use MySQL as alpha's backend database： 

1.  I package the distribution version use： mvn clean install -DskipTests=true -Prelease
2.  prepare mysql 5.7 db，copy mysql-connector-java-8.0.15.jar in libs2 dictionary
3. run command： java -Dspring.profiles.active=mysql -Dloader.path=./libs2 -D"spring.datasource.url=jdbc:mysql://127.0.0.1:3308/saga?serverTimezone=GMT%2b8&useSSL=false" -jar alpha-server-0.4.0-SNAPSHOT-exec.jar

but encounter one problem， the log： 

```java
17:34:30.224 [main] ERROR org.springframework.boot.web.embedded.tomcat.TomcatStarter - Error starting Tomcat context. Exception: org.springframework.beans.factory.BeanCreationException.
 Message: Error creating bean with name 'servletEndpointRegistrar' defined in class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementConte
xtConfiguration$WebMvcServletEndpointManagementContextConfiguration.class]: Bean 
instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate 
[org.springframework.boot.actuate.endpoint.web.ServletEndpointRegistrar]: Factory method 'servletEndpointRegistrar' threw exception; nested exception is 
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'healthEndpoint' defined in class path resource 
[org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]: 
Unsatisfied dependency expressed through method 'healthEndpoint' parameter 1; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name
 'healthIndicatorRegistry' defined in class path resource 
[org/springframework/boot/actuate/autoconfigure/health/HealthIndicatorAutoConfiguration.class]: Bean instantiation via factory method failed; nested exception is 
org.springframework.beans.BeanInstantiationException: Failed to instantiate 
[org.springframework.boot.actuate.health.HealthIndicatorRegistry]: Factory method 'healthIndicatorRegistry' threw exception; nested exception is 
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 
'org.springframework.boot.actuate.autoconfigure.jdbc.DataSourceHealthIndicatorAutoConfiguration': Bean instantiation via constructor failed; nested exception is 
org.springframework.beans.BeanInstantiationException: Failed to instantiate 
[org.springframework.boot.actuate.autoconfigure.jdbc.DataSourceHealthIndicatorAutoConfiguration$$EnhancerBySpringCGLIB$$5c582c25]: Constructor threw exception; nested exception is 
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 
'dataSource': Post-processing of FactoryBean's singleton object failed; nested exception is 
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 
'org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerInvoker': Invocation of init 
method failed; nested exception is org.springframework.jdbc.datasource.init.ScriptStatementFailedException: Failed to execute SQL
 script statement #7 of URL [jar:file:/Users/yss/work/servicecomb-pack/distribution/target/apache-servicecomb-pack-distribution-0.4.0-SNAPSHOT-bin/alpha-server-0.4.0-SNAPSHOT-
exec.jar!/BOOT-INF/classes!/schema-mysql.sql]: CREATE TABLE IF NOT EXISTS master_lock ( 
serviceName varchar(36) not NULL, expireTime timestamp(3) not NULL, lockedTime timestamp(3) not NULL, instanceId varchar(255) not NULL, PRIMARY KEY (serviceName) ) ENGINE=InnoDB 
DEFAULT CHARSET=utf8; nested exception is java.sql.SQLSyntaxErrorException: Invalid default 
value for 'lockedTime'

```