### PR TITLE
SCB-1353 Make script/test.sh fail fast.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ then
   echo "Don't do anything here for the cron job!"
 else
   echo "Running the unit tests and integration tests here!"
-  mvn clean install -Pjacoco -Pdocker -P${SPRING_BOOT_PROFILE} coveralls:report
-  mvn clean verify -f demo -Pdemo -Pdocker -P${SPRING_BOOT_PROFILE} -Ddocker.useColor=false -Ddocker.showLogs
-  mvn clean verify -f acceptance-tests -Pdemo -Pdocker -P${SPRING_BOOT_PROFILE} -Ddocker.useColor=false -Ddocker.showLogs
+  mvn clean install -Pjacoco -Pdocker -P${SPRING_BOOT_PROFILE} coveralls:report \
+    && mvn clean verify -f demo -Pdemo -Pdocker -P${SPRING_BOOT_PROFILE} -Ddocker.useColor=false -Ddocker.showLogs \
+    && mvn clean verify -f acceptance-tests -Pdemo -Pdocker -P${SPRING_BOOT_PROFILE} -Ddocker.useColor=false -Ddocker.showLogs
 fi


### PR DESCRIPTION
Currently script/test.sh contains 3 mvn command execution, it
will continue even if previous mvn command execution failed,
that makes it hard to find out why build fails from pretty long
build logs. So make it fail fast if previous mvn command
execution fails will be helpful.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
