### PR TITLE
[SCB-1381] Rename MetricsController to APIControllerV1 and move to pack…

### DIFF
--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/api/APIControllerV1.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/api/APIControllerV1.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.servicecomb.pack.alpha.server.api.v1;
+package org.apache.servicecomb.pack.alpha.server.api;
 
 import org.apache.servicecomb.pack.alpha.server.metrics.AlphaMetrics;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/alpha/api/v1")
-public class MetricsController {
+public class APIControllerV1 {
 
   @Autowired
   AlphaMetrics AlphaMetrics;


### PR DESCRIPTION
Rename MetricsController to APIControllerV1 and move to package org.apache.servicecomb.pack.alpha.server.api
