### PR TITLE
fix issue #571

### DIFF
--- a/omega/omega-transport/omega-transport-feign/pom.xml
+++ b/omega/omega-transport/omega-transport-feign/pom.xml
@@ -28,6 +28,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>omega-transport-feign</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>io.github.openfeign</groupId>
@@ -70,6 +82,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>1.5.18</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/FeignAutoConfiguration.java
+++ b/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/FeignAutoConfiguration.java
@@ -19,12 +19,15 @@ package org.apache.servicecomb.pack.omega.transport.feign;
 
 import feign.RequestInterceptor;
 import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.apache.servicecomb.pack.omega.transport.feign.hystrix.HystrixServiceCombAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import(HystrixServiceCombAutoConfiguration.class)
 public class FeignAutoConfiguration {
 
     @Bean

--- a/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/HystrixCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/HystrixCallableWrapper.java
@@ -1,0 +1,29 @@
+package org.apache.servicecomb.pack.omega.transport.feign.hystrix;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 自定义包装hystrix callable 接口，便于处理线程变量等
+ * @author : qixiangyu18@163.com
+ */
+public interface HystrixCallableWrapper {
+
+    /**
+     * is need wrap
+     * @return  return true will invoke  {@link #wrapCallable(Callable)}
+     */
+    boolean shouldWrap();
+
+    /**
+     * Provides an opportunity to wrap/decorate a {@code Callable<T>} before execution.
+     * <p>
+     * This can be used to inject additional behavior such as copying of thread state (such as {@link ThreadLocal}).
+     *
+     * @param callable
+     *            {@code Callable<T>} to be executed via a {@link ThreadPoolExecutor}
+     * @return {@code Callable<T>} either as a pass-thru or wrapping the one given
+     */
+    <T> Callable<T> wrapCallable(Callable<T> callable);
+
+}

--- a/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/HystrixServiceCombAutoConfiguration.java
+++ b/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/HystrixServiceCombAutoConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.feign.hystrix;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Optional;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+/**
+ * 使用hystrix情况下，自动注册ServiceCombConcurrencyStrategy
+ * @author : qixiangyu18@163.com
+ */
+@Configuration
+@Order
+@ConditionalOnClass({Hystrix.class})
+public class HystrixServiceCombAutoConfiguration {
+
+	@Autowired
+	Optional<List<HystrixCallableWrapper>> hystrixCallableWrappers;
+
+	@PostConstruct
+	public void init() {
+		// Keeps references of existing Hystrix plugins.
+		HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance()
+				.getEventNotifier();
+		HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance()
+				.getMetricsPublisher();
+		HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance()
+				.getPropertiesStrategy();
+		HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins.getInstance()
+				.getCommandExecutionHook();
+		HystrixConcurrencyStrategy concurrencyStrategy = detectRegisteredConcurrencyStrategy();
+
+		HystrixPlugins.reset();
+
+		// Registers existing plugins excepts the Concurrent Strategy plugin.
+		HystrixPlugins.getInstance().registerConcurrencyStrategy(
+				new ServiceCombConcurrencyStrategy(concurrencyStrategy,hystrixCallableWrappers));
+		HystrixPlugins.getInstance().registerEventNotifier(eventNotifier);
+		HystrixPlugins.getInstance().registerMetricsPublisher(metricsPublisher);
+		HystrixPlugins.getInstance().registerPropertiesStrategy(propertiesStrategy);
+		HystrixPlugins.getInstance().registerCommandExecutionHook(commandExecutionHook);
+	}
+
+	private HystrixConcurrencyStrategy detectRegisteredConcurrencyStrategy() {
+		return HystrixPlugins.getInstance()
+				.getConcurrencyStrategy();
+	}
+
+	@Bean
+	@ConditionalOnBean(OmegaContext.class)
+	public OmegaContextCallableWrapper omegaContextCallableWrapper(OmegaContext context) {
+		return new OmegaContextCallableWrapper(context);
+	}
+
+}

--- a/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/OmegaContextCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/OmegaContextCallableWrapper.java
@@ -1,0 +1,59 @@
+package org.apache.servicecomb.pack.omega.transport.feign.hystrix;
+
+import java.util.concurrent.Callable;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+
+/**
+ * 处理omegaContext在feign开启hystrix情况下，线程变量传递问题
+ * @author : qixiangyu18@163.com
+ */
+public class OmegaContextCallableWrapper implements HystrixCallableWrapper {
+
+    private OmegaContext context;
+
+    public OmegaContextCallableWrapper(OmegaContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public boolean shouldWrap() {
+        if (context == null || StringUtils.isEmpty(context.globalTxId()) || StringUtils.isEmpty(context.localTxId())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+        return new WrappedCallable<>(callable, context.globalTxId(), context.localTxId(), context);
+    }
+
+    static class WrappedCallable<T> implements Callable<T> {
+
+        private final Callable<T> target;
+
+        private final String globalTxId;
+        private final String localTxId;
+        private final OmegaContext omegaContext;
+
+        public WrappedCallable(Callable<T> target, String globalTxId, String localTxId, OmegaContext omegaContext) {
+            this.target = target;
+            this.omegaContext = omegaContext;
+            this.globalTxId = globalTxId;
+            this.localTxId = localTxId;
+        }
+
+        @Override
+        public T call() throws Exception {
+            try {
+                omegaContext.setGlobalTxId(globalTxId);
+                omegaContext.setLocalTxId(localTxId);
+                return target.call();
+            } finally {
+                omegaContext.clear();
+            }
+        }
+    }
+}

--- a/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/ServiceCombConcurrencyStrategy.java
+++ b/omega/omega-transport/omega-transport-feign/src/main/java/org/apache/servicecomb/pack/omega/transport/feign/hystrix/ServiceCombConcurrencyStrategy.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.feign.hystrix;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+
+/**
+ * HystrixConcurrencyStrategy 代理，开放接口实现扩展包装wrapCallable，便于传递线程变量
+ * @author : qixiangyu18@163.com
+ */
+public class ServiceCombConcurrencyStrategy extends HystrixConcurrencyStrategy {
+
+	private HystrixConcurrencyStrategy existingConcurrencyStrategy;
+	private List<HystrixCallableWrapper> hystrixCallableWrappers;
+
+	public ServiceCombConcurrencyStrategy(
+			HystrixConcurrencyStrategy existingConcurrencyStrategy,
+			Optional<List<HystrixCallableWrapper>> optionalHystrixCallableWrappers) {
+		this.existingConcurrencyStrategy = existingConcurrencyStrategy;
+		this.hystrixCallableWrappers = optionalHystrixCallableWrappers.orElseGet(Collections::emptyList);
+	}
+
+	@Override
+	public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
+		return existingConcurrencyStrategy != null
+				? existingConcurrencyStrategy.getBlockingQueue(maxQueueSize)
+				: super.getBlockingQueue(maxQueueSize);
+	}
+
+	@Override
+	public <T> HystrixRequestVariable<T> getRequestVariable(
+			HystrixRequestVariableLifecycle<T> rv) {
+		return existingConcurrencyStrategy != null
+				? existingConcurrencyStrategy.getRequestVariable(rv)
+				: super.getRequestVariable(rv);
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixProperty<Integer> corePoolSize,
+			HystrixProperty<Integer> maximumPoolSize,
+			HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+			BlockingQueue<Runnable> workQueue) {
+		return existingConcurrencyStrategy != null
+				? existingConcurrencyStrategy.getThreadPool(threadPoolKey, corePoolSize,
+						maximumPoolSize, keepAliveTime, unit, workQueue)
+				: super.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+						keepAliveTime, unit, workQueue);
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixThreadPoolProperties threadPoolProperties) {
+		return existingConcurrencyStrategy != null
+				? existingConcurrencyStrategy.getThreadPool(threadPoolKey,
+						threadPoolProperties)
+				: super.getThreadPool(threadPoolKey, threadPoolProperties);
+	}
+
+	@Override
+	public <T> Callable<T> wrapCallable(Callable<T> callable) {
+		//Invoke custom callable wrapper
+		for(HystrixCallableWrapper callableWrapper : hystrixCallableWrappers){
+			if(callableWrapper.shouldWrap()){
+				callable = callableWrapper.wrapCallable(callable);
+			}
+		}
+		return existingConcurrencyStrategy != null
+				? existingConcurrencyStrategy
+						.wrapCallable(callable)
+				: super.wrapCallable(callable);
+	}
+
+}


### PR DESCRIPTION
解决issue #571 
OmegaContext 中使用了 InheritableThreadLocal
在feign调用开启hystrix时,hystrix会为每个feignClient创建线程池.
InheritableThreadLocal在第一次创建线程时,可以正确继承到父线程的线程变量,但是当线程被复用时,InheritableThreadLocal不会被更新,导致无法在feign调用的header里传递globalTxId和localTxId

我参考了spring security解决securityContext 线程变量在使用hystrix时,传递线程变量的方案,针对OmegaContext里的线程变量进行了传递,并提供了可扩展的接口