### PR TITLE
SCB-1530 Add omega-transport-hystrix

### DIFF
--- a/omega/omega-transport/omega-transport-hystrix/pom.xml
+++ b/omega/omega-transport/omega-transport-hystrix/pom.xml
@@ -16,42 +16,41 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>omega-transport</artifactId>
-        <groupId>org.apache.servicecomb.pack</groupId>
-        <version>0.6.0-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>omega-transport</artifactId>
+    <groupId>org.apache.servicecomb.pack</groupId>
+    <version>0.6.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>omega-transport-hystrix</artifactId>
+  <artifactId>omega-transport-hystrix</artifactId>
 
-    <dependencies>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.netflix.hystrix</groupId>
-            <artifactId>hystrix-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/omega/omega-transport/omega-transport-hystrix/pom.xml
+++ b/omega/omega-transport/omega-transport-hystrix/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>omega-transport</artifactId>
+        <groupId>org.apache.servicecomb.pack</groupId>
+        <version>0.6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>omega-transport-hystrix</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
@@ -25,21 +25,22 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 public interface HystrixCallableWrapper {
 
-    /**
-     * is need wrap
-     *
-     * @return return true will invoke  {@link #wrapCallable(Callable)}
-     */
-    boolean shouldWrap();
+  /**
+   * is need wrap
+   *
+   * @return return true will invoke  {@link #wrapCallable(Callable)}
+   */
+  boolean shouldWrap();
 
-    /**
-     * Provides an opportunity to wrap/decorate a {@code Callable<T>} before execution.
-     * <p>
-     * This can be used to inject additional behavior such as copying of thread state (such as {@link ThreadLocal}).
-     *
-     * @param callable {@code Callable<T>} to be executed via a {@link ThreadPoolExecutor}
-     * @return {@code Callable<T>} either as a pass-thru or wrapping the one given
-     */
-    <T> Callable<T> wrapCallable(Callable<T> callable);
+  /**
+   * Provides an opportunity to wrap/decorate a {@code Callable<T>} before execution.
+   * <p>
+   * This can be used to inject additional behavior such as copying of thread state (such as {@link
+   * ThreadLocal}).
+   *
+   * @param callable {@code Callable<T>} to be executed via a {@link ThreadPoolExecutor}
+   * @return {@code Callable<T>} either as a pass-thru or wrapping the one given
+   */
+  <T> Callable<T> wrapCallable(Callable<T> callable);
 
 }

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
@@ -1,10 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.servicecomb.pack.omega.transport.hystrix;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
- * 自定义包装hystrix callable 接口，便于处理线程变量等
+ * custom hystrix callable wrapper
  */
 public interface HystrixCallableWrapper {
 

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixCallableWrapper.java
@@ -1,0 +1,28 @@
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 自定义包装hystrix callable 接口，便于处理线程变量等
+ */
+public interface HystrixCallableWrapper {
+
+    /**
+     * is need wrap
+     *
+     * @return return true will invoke  {@link #wrapCallable(Callable)}
+     */
+    boolean shouldWrap();
+
+    /**
+     * Provides an opportunity to wrap/decorate a {@code Callable<T>} before execution.
+     * <p>
+     * This can be used to inject additional behavior such as copying of thread state (such as {@link ThreadLocal}).
+     *
+     * @param callable {@code Callable<T>} to be executed via a {@link ThreadPoolExecutor}
+     * @return {@code Callable<T>} either as a pass-thru or wrapping the one given
+     */
+    <T> Callable<T> wrapCallable(Callable<T> callable);
+
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixServiceCombAutoConfiguration.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixServiceCombAutoConfiguration.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * 使用hystrix情况下，自动注册ServiceCombConcurrencyStrategy
+ * 参考 org.springframework.cloud.netflix.hystrix.security.HystrixSecurityAutoConfigurations
+ */
+@Configuration
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+@ConditionalOnClass({Hystrix.class})
+public class HystrixServiceCombAutoConfiguration {
+
+    private static final Log log = LogFactory.getLog(HystrixServiceCombAutoConfiguration.class);
+
+    @Autowired(required = false)
+    List<HystrixCallableWrapper> hystrixCallableWrappers;
+
+    @PostConstruct
+    public void init() {
+        try {
+            if (CollectionUtils.isEmpty(hystrixCallableWrappers)) {
+                log.info("no hystrixCallableWrapper find ,ServiceCombConcurrencyStrategy ignore Configuration");
+                return;
+            }
+            HystrixConcurrencyStrategy concurrencyStrategy = detectRegisteredConcurrencyStrategy();
+            if (concurrencyStrategy instanceof ServiceCombConcurrencyStrategy) {
+                log.info("Current Hystrix plugins concurrencyStrategy is ServiceCombConcurrencyStrategy ignore Configuration");
+                return;
+            }
+
+            // Keeps references of existing Hystrix plugins.
+            HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance()
+                    .getEventNotifier();
+            HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance()
+                    .getMetricsPublisher();
+            HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance()
+                    .getPropertiesStrategy();
+            HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins.getInstance()
+                    .getCommandExecutionHook();
+
+            log.info("Current Hystrix plugins configuration is ["
+                    + "concurrencyStrategy [" + concurrencyStrategy + "]," + "eventNotifier ["
+                    + eventNotifier + "]," + "metricPublisher [" + metricsPublisher + "],"
+                    + "propertiesStrategy [" + propertiesStrategy + "]," + "]");
+            HystrixPlugins.reset();
+
+            // Registers existing plugins excepts the Concurrent Strategy plugin.
+            HystrixPlugins.getInstance().registerConcurrencyStrategy(
+                    new ServiceCombConcurrencyStrategy(concurrencyStrategy, hystrixCallableWrappers));
+            HystrixPlugins.getInstance().registerEventNotifier(eventNotifier);
+            HystrixPlugins.getInstance().registerMetricsPublisher(metricsPublisher);
+            HystrixPlugins.getInstance().registerPropertiesStrategy(propertiesStrategy);
+            HystrixPlugins.getInstance().registerCommandExecutionHook(commandExecutionHook);
+
+            log.info("Succeeded to register ServiceComb Hystrix Concurrency Strategy");
+
+        } catch (Exception e) {
+            log.error("Failed to register ServiceComb Hystrix Concurrency Strategy", e);
+        }
+
+    }
+
+    private HystrixConcurrencyStrategy detectRegisteredConcurrencyStrategy() {
+        return HystrixPlugins.getInstance()
+                .getConcurrencyStrategy();
+    }
+
+    @Bean
+    @ConditionalOnBean(OmegaContext.class)
+    public OmegaContextCallableWrapper omegaContextCallableWrapper(OmegaContext context) {
+        return new OmegaContextCallableWrapper(context);
+    }
+
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixServiceCombAutoConfiguration.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixServiceCombAutoConfiguration.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,8 +40,9 @@ import org.springframework.core.Ordered;
 import org.springframework.util.CollectionUtils;
 
 /**
- * 使用hystrix情况下，自动注册ServiceCombConcurrencyStrategy
- * 参考 org.springframework.cloud.netflix.hystrix.security.HystrixSecurityAutoConfigurations
+ * if use hystrix ,auto configuration ServiceCombConcurrencyStrategy
+ * <p>
+ * see org.springframework.cloud.netflix.hystrix.security.HystrixSecurityAutoConfigurations
  */
 @Configuration
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
@@ -1,0 +1,55 @@
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import java.util.concurrent.Callable;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+
+/**
+ * 处理omegaContext在开启hystrix情况下，线程变量传递问题
+ */
+public class OmegaContextCallableWrapper implements HystrixCallableWrapper {
+
+    private OmegaContext context;
+
+    public OmegaContextCallableWrapper(OmegaContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public boolean shouldWrap() {
+        return context != null && StringUtils.isNotEmpty(context.globalTxId());
+    }
+
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+        return new WrappedCallable<>(callable, context.globalTxId(), context.localTxId(), context);
+    }
+
+    static class WrappedCallable<T> implements Callable<T> {
+
+        private final Callable<T> target;
+
+        private final String globalTxId;
+        private final String localTxId;
+        private final OmegaContext omegaContext;
+
+        public WrappedCallable(Callable<T> target, String globalTxId, String localTxId, OmegaContext omegaContext) {
+            this.target = target;
+            this.omegaContext = omegaContext;
+            this.globalTxId = globalTxId;
+            this.localTxId = localTxId;
+        }
+
+        @Override
+        public T call() throws Exception {
+            try {
+                omegaContext.setGlobalTxId(globalTxId);
+                omegaContext.setLocalTxId(localTxId);
+                return target.call();
+            } finally {
+                omegaContext.clear();
+            }
+        }
+    }
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
@@ -18,7 +18,6 @@
 package org.apache.servicecomb.pack.omega.transport.hystrix;
 
 import java.util.concurrent.Callable;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.servicecomb.pack.omega.context.OmegaContext;
 
@@ -27,46 +26,47 @@ import org.apache.servicecomb.pack.omega.context.OmegaContext;
  */
 public class OmegaContextCallableWrapper implements HystrixCallableWrapper {
 
-    private OmegaContext context;
+  private OmegaContext context;
 
-    public OmegaContextCallableWrapper(OmegaContext context) {
-        this.context = context;
+  public OmegaContextCallableWrapper(OmegaContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean shouldWrap() {
+    return context != null && StringUtils.isNotEmpty(context.globalTxId());
+  }
+
+  @Override
+  public <T> Callable<T> wrapCallable(Callable<T> callable) {
+    return new WrappedCallable<>(callable, context.globalTxId(), context.localTxId(), context);
+  }
+
+  static class WrappedCallable<T> implements Callable<T> {
+
+    private final Callable<T> target;
+
+    private final String globalTxId;
+    private final String localTxId;
+    private final OmegaContext omegaContext;
+
+    public WrappedCallable(Callable<T> target, String globalTxId, String localTxId,
+        OmegaContext omegaContext) {
+      this.target = target;
+      this.omegaContext = omegaContext;
+      this.globalTxId = globalTxId;
+      this.localTxId = localTxId;
     }
 
     @Override
-    public boolean shouldWrap() {
-        return context != null && StringUtils.isNotEmpty(context.globalTxId());
+    public T call() throws Exception {
+      try {
+        omegaContext.setGlobalTxId(globalTxId);
+        omegaContext.setLocalTxId(localTxId);
+        return target.call();
+      } finally {
+        omegaContext.clear();
+      }
     }
-
-    @Override
-    public <T> Callable<T> wrapCallable(Callable<T> callable) {
-        return new WrappedCallable<>(callable, context.globalTxId(), context.localTxId(), context);
-    }
-
-    static class WrappedCallable<T> implements Callable<T> {
-
-        private final Callable<T> target;
-
-        private final String globalTxId;
-        private final String localTxId;
-        private final OmegaContext omegaContext;
-
-        public WrappedCallable(Callable<T> target, String globalTxId, String localTxId, OmegaContext omegaContext) {
-            this.target = target;
-            this.omegaContext = omegaContext;
-            this.globalTxId = globalTxId;
-            this.localTxId = localTxId;
-        }
-
-        @Override
-        public T call() throws Exception {
-            try {
-                omegaContext.setGlobalTxId(globalTxId);
-                omegaContext.setLocalTxId(localTxId);
-                return target.call();
-            } finally {
-                omegaContext.clear();
-            }
-        }
-    }
+  }
 }

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/OmegaContextCallableWrapper.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.servicecomb.pack.omega.transport.hystrix;
 
 import java.util.concurrent.Callable;
@@ -6,7 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.servicecomb.pack.omega.context.OmegaContext;
 
 /**
- * 处理omegaContext在开启hystrix情况下，线程变量传递问题
+ * process omegaContext ，passing threadLocal variables
  */
 public class OmegaContextCallableWrapper implements HystrixCallableWrapper {
 

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+
+/**
+ * HystrixConcurrencyStrategy 代理，开放接口实现扩展包装wrapCallable，便于传递线程变量
+ */
+public class ServiceCombConcurrencyStrategy extends HystrixConcurrencyStrategy {
+
+    private HystrixConcurrencyStrategy existingConcurrencyStrategy;
+    private List<HystrixCallableWrapper> hystrixCallableWrappers;
+
+    public ServiceCombConcurrencyStrategy(
+            HystrixConcurrencyStrategy existingConcurrencyStrategy,
+            List<HystrixCallableWrapper> optionalHystrixCallableWrappers) {
+        this.existingConcurrencyStrategy = existingConcurrencyStrategy;
+        this.hystrixCallableWrappers = optionalHystrixCallableWrappers == null ? Collections.<HystrixCallableWrapper>emptyList() : optionalHystrixCallableWrappers;
+    }
+
+    @Override
+    public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
+        return existingConcurrencyStrategy != null
+                ? existingConcurrencyStrategy.getBlockingQueue(maxQueueSize)
+                : super.getBlockingQueue(maxQueueSize);
+    }
+
+    @Override
+    public <T> HystrixRequestVariable<T> getRequestVariable(
+            HystrixRequestVariableLifecycle<T> rv) {
+        return existingConcurrencyStrategy != null
+                ? existingConcurrencyStrategy.getRequestVariable(rv)
+                : super.getRequestVariable(rv);
+    }
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+                                            HystrixProperty<Integer> corePoolSize,
+                                            HystrixProperty<Integer> maximumPoolSize,
+                                            HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue) {
+        return existingConcurrencyStrategy != null
+                ? existingConcurrencyStrategy.getThreadPool(threadPoolKey, corePoolSize,
+                maximumPoolSize, keepAliveTime, unit, workQueue)
+                : super.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+                keepAliveTime, unit, workQueue);
+    }
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+                                            HystrixThreadPoolProperties threadPoolProperties) {
+        return existingConcurrencyStrategy != null
+                ? existingConcurrencyStrategy.getThreadPool(threadPoolKey,
+                threadPoolProperties)
+                : super.getThreadPool(threadPoolKey, threadPoolProperties);
+    }
+
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+        //Invoke custom callable wrapper
+        for (HystrixCallableWrapper callableWrapper : hystrixCallableWrappers) {
+            if (callableWrapper.shouldWrap()) {
+                callable = callableWrapper.wrapCallable(callable);
+            }
+        }
+        return existingConcurrencyStrategy != null
+                ? existingConcurrencyStrategy
+                .wrapCallable(callable)
+                : super.wrapCallable(callable);
+    }
+
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
@@ -17,6 +17,12 @@
 
 package org.apache.servicecomb.pack.omega.transport.hystrix;
 
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -24,77 +30,73 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import com.netflix.hystrix.HystrixThreadPoolKey;
-import com.netflix.hystrix.HystrixThreadPoolProperties;
-import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
-import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
-import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
-import com.netflix.hystrix.strategy.properties.HystrixProperty;
-
 /**
- * HystrixConcurrencyStrategy proxy，invoke HystrixCallableWrapper，make sure threadLocal variables can be inheritable
+ * HystrixConcurrencyStrategy proxy，invoke HystrixCallableWrapper，make sure threadLocal variables
+ * can be inheritable
  */
 public class ServiceCombConcurrencyStrategy extends HystrixConcurrencyStrategy {
 
-    private HystrixConcurrencyStrategy existingConcurrencyStrategy;
-    private List<HystrixCallableWrapper> hystrixCallableWrappers;
+  private HystrixConcurrencyStrategy existingConcurrencyStrategy;
+  private List<HystrixCallableWrapper> hystrixCallableWrappers;
 
-    public ServiceCombConcurrencyStrategy(
-            HystrixConcurrencyStrategy existingConcurrencyStrategy,
-            List<HystrixCallableWrapper> optionalHystrixCallableWrappers) {
-        this.existingConcurrencyStrategy = existingConcurrencyStrategy;
-        this.hystrixCallableWrappers = optionalHystrixCallableWrappers == null ? Collections.<HystrixCallableWrapper>emptyList() : optionalHystrixCallableWrappers;
-    }
+  public ServiceCombConcurrencyStrategy(
+      HystrixConcurrencyStrategy existingConcurrencyStrategy,
+      List<HystrixCallableWrapper> optionalHystrixCallableWrappers) {
+    this.existingConcurrencyStrategy = existingConcurrencyStrategy;
+    this.hystrixCallableWrappers =
+        optionalHystrixCallableWrappers == null ? Collections.<HystrixCallableWrapper>emptyList()
+            : optionalHystrixCallableWrappers;
+  }
 
-    @Override
-    public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
-        return existingConcurrencyStrategy != null
-                ? existingConcurrencyStrategy.getBlockingQueue(maxQueueSize)
-                : super.getBlockingQueue(maxQueueSize);
-    }
+  @Override
+  public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
+    return existingConcurrencyStrategy != null
+        ? existingConcurrencyStrategy.getBlockingQueue(maxQueueSize)
+        : super.getBlockingQueue(maxQueueSize);
+  }
 
-    @Override
-    public <T> HystrixRequestVariable<T> getRequestVariable(
-            HystrixRequestVariableLifecycle<T> rv) {
-        return existingConcurrencyStrategy != null
-                ? existingConcurrencyStrategy.getRequestVariable(rv)
-                : super.getRequestVariable(rv);
-    }
+  @Override
+  public <T> HystrixRequestVariable<T> getRequestVariable(
+      HystrixRequestVariableLifecycle<T> rv) {
+    return existingConcurrencyStrategy != null
+        ? existingConcurrencyStrategy.getRequestVariable(rv)
+        : super.getRequestVariable(rv);
+  }
 
-    @Override
-    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
-                                            HystrixProperty<Integer> corePoolSize,
-                                            HystrixProperty<Integer> maximumPoolSize,
-                                            HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
-                                            BlockingQueue<Runnable> workQueue) {
-        return existingConcurrencyStrategy != null
-                ? existingConcurrencyStrategy.getThreadPool(threadPoolKey, corePoolSize,
-                maximumPoolSize, keepAliveTime, unit, workQueue)
-                : super.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
-                keepAliveTime, unit, workQueue);
-    }
+  @Override
+  public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+      HystrixProperty<Integer> corePoolSize,
+      HystrixProperty<Integer> maximumPoolSize,
+      HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+      BlockingQueue<Runnable> workQueue) {
+    return existingConcurrencyStrategy != null
+        ? existingConcurrencyStrategy.getThreadPool(threadPoolKey, corePoolSize,
+        maximumPoolSize, keepAliveTime, unit, workQueue)
+        : super.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+            keepAliveTime, unit, workQueue);
+  }
 
-    @Override
-    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
-                                            HystrixThreadPoolProperties threadPoolProperties) {
-        return existingConcurrencyStrategy != null
-                ? existingConcurrencyStrategy.getThreadPool(threadPoolKey,
-                threadPoolProperties)
-                : super.getThreadPool(threadPoolKey, threadPoolProperties);
-    }
+  @Override
+  public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+      HystrixThreadPoolProperties threadPoolProperties) {
+    return existingConcurrencyStrategy != null
+        ? existingConcurrencyStrategy.getThreadPool(threadPoolKey,
+        threadPoolProperties)
+        : super.getThreadPool(threadPoolKey, threadPoolProperties);
+  }
 
-    @Override
-    public <T> Callable<T> wrapCallable(Callable<T> callable) {
-        //Invoke custom callable wrapper
-        for (HystrixCallableWrapper callableWrapper : hystrixCallableWrappers) {
-            if (callableWrapper.shouldWrap()) {
-                callable = callableWrapper.wrapCallable(callable);
-            }
-        }
-        return existingConcurrencyStrategy != null
-                ? existingConcurrencyStrategy
-                .wrapCallable(callable)
-                : super.wrapCallable(callable);
+  @Override
+  public <T> Callable<T> wrapCallable(Callable<T> callable) {
+    //Invoke custom callable wrapper
+    for (HystrixCallableWrapper callableWrapper : hystrixCallableWrappers) {
+      if (callableWrapper.shouldWrap()) {
+        callable = callableWrapper.wrapCallable(callable);
+      }
     }
+    return existingConcurrencyStrategy != null
+        ? existingConcurrencyStrategy
+        .wrapCallable(callable)
+        : super.wrapCallable(callable);
+  }
 
 }

--- a/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/java/org/apache/servicecomb/pack/omega/transport/hystrix/ServiceCombConcurrencyStrategy.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +32,7 @@ import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
 import com.netflix.hystrix.strategy.properties.HystrixProperty;
 
 /**
- * HystrixConcurrencyStrategy 代理，开放接口实现扩展包装wrapCallable，便于传递线程变量
+ * HystrixConcurrencyStrategy proxy，invoke HystrixCallableWrapper，make sure threadLocal variables can be inheritable
  */
 public class ServiceCombConcurrencyStrategy extends HystrixConcurrencyStrategy {
 

--- a/omega/omega-transport/omega-transport-hystrix/src/main/resources/META-INF/spring.factories
+++ b/omega/omega-transport/omega-transport-hystrix/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.apache.servicecomb.pack.omega.transport.hystrix.HystrixServiceCombAutoConfiguration

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixConcurrencyStrategyTests.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixConcurrencyStrategyTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import com.netflix.hystrix.*;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 使用ServiceCombConcurrencyStrategy，omegaContext的线程变量能正确传递
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootTest(classes = HystrixTestApplication.class)
+public class HystrixConcurrencyStrategyTests {
+
+    @Autowired
+    private OmegaContext omegaContext;
+
+    @Test
+    public void testConcurrencyStrategyInstalled() {
+
+        HystrixConcurrencyStrategy concurrencyStrategy = HystrixPlugins.getInstance()
+                .getConcurrencyStrategy();
+        assertThat(concurrencyStrategy)
+                .isInstanceOf(ServiceCombConcurrencyStrategy.class);
+    }
+
+    @Test
+    public void testCircuitBreaker() {
+        for (int i = 0; i < 5; i++) {
+            try {
+                omegaContext.newGlobalTxId();
+                HystrixCommand<String> command = new TestCircuitBreakerCommand("testCircuitBreaker", omegaContext);
+                String result = command.execute();
+                //与父线程的GlobalTxId一致,LocalTxId同理
+                Assert.assertEquals(result, omegaContext.globalTxId());
+            } finally {
+                omegaContext.clear();
+            }
+        }
+    }
+
+
+    public static class TestCircuitBreakerCommand extends HystrixCommand<String> {
+
+        private final OmegaContext omegaContext;
+
+        public TestCircuitBreakerCommand(String name, OmegaContext omegaContext) {
+            super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("ThreadPoolTestGroup"))
+                    .andCommandKey(HystrixCommandKey.Factory.asKey("testCommandKey"))
+                    .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(name))
+                    .andThreadPoolPropertiesDefaults(
+                            HystrixThreadPoolProperties.Setter()
+                                    .withMaxQueueSize(10)   //配置队列大小
+                                    .withCoreSize(3)    // 配置线程池里的线程数
+                                    .withMaximumSize(3) // 与coreSize一致确保不会创建额外线程，方便观察
+                    )
+
+            );
+            this.omegaContext = omegaContext;
+        }
+
+        @Override
+        protected String run() {
+            //返回线程变量
+            return this.omegaContext.globalTxId();
+        }
+    }
+
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixConcurrencyStrategyTests.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixConcurrencyStrategyTests.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 使用ServiceCombConcurrencyStrategy，omegaContext的线程变量能正确传递
+ * use ServiceCombConcurrencyStrategy，threadLocal variables  can not be inheritable
  */
 @RunWith(SpringRunner.class)
 @DirtiesContext
@@ -57,7 +58,7 @@ public class HystrixConcurrencyStrategyTests {
                 omegaContext.newGlobalTxId();
                 HystrixCommand<String> command = new TestCircuitBreakerCommand("testCircuitBreaker", omegaContext);
                 String result = command.execute();
-                //与父线程的GlobalTxId一致,LocalTxId同理
+                //inheritable GlobalTxId
                 Assert.assertEquals(result, omegaContext.globalTxId());
             } finally {
                 omegaContext.clear();
@@ -76,9 +77,9 @@ public class HystrixConcurrencyStrategyTests {
                     .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(name))
                     .andThreadPoolPropertiesDefaults(
                             HystrixThreadPoolProperties.Setter()
-                                    .withMaxQueueSize(10)   //配置队列大小
-                                    .withCoreSize(3)    // 配置线程池里的线程数
-                                    .withMaximumSize(3) // 与coreSize一致确保不会创建额外线程，方便观察
+                                    .withMaxQueueSize(10)
+                                    .withCoreSize(3)
+                                    .withMaximumSize(3)
                     )
 
             );
@@ -87,7 +88,7 @@ public class HystrixConcurrencyStrategyTests {
 
         @Override
         protected String run() {
-            //返回线程变量
+            //return threadLocal variable
             return this.omegaContext.globalTxId();
         }
     }

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.apache.servicecomb.pack.omega.context.UniqueIdGenerator;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SpringBootApplication
+public class HystrixTestApplication {
+
+    /**
+     * 注册omegaContext，会自动注册
+     *
+     * @return
+     */
+    @Bean
+    public OmegaContext omegaContext() {
+        return new OmegaContext(new UniqueIdGenerator());
+    }
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,11 +27,6 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootApplication
 public class HystrixTestApplication {
 
-    /**
-     * 注册omegaContext，会自动注册
-     *
-     * @return
-     */
     @Bean
     public OmegaContext omegaContext() {
         return new OmegaContext(new UniqueIdGenerator());

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixTestApplication.java
@@ -27,8 +27,8 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootApplication
 public class HystrixTestApplication {
 
-    @Bean
-    public OmegaContext omegaContext() {
-        return new OmegaContext(new UniqueIdGenerator());
-    }
+  @Bean
+  public OmegaContext omegaContext() {
+    return new OmegaContext(new UniqueIdGenerator());
+  }
 }

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.omega.transport.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
+import org.apache.servicecomb.pack.omega.context.UniqueIdGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 默认策略下，omegaContext的线程变量无法正确传递
+ */
+
+public class HystrixWithoutConcurrencyStrategyTests {
+
+    private OmegaContext omegaContext = new OmegaContext(new UniqueIdGenerator());
+
+    @Test
+    public void testCircuitBreakerWithoutServiceCombConcurrencyStrategy() {
+
+        for (int i = 0; i < 5; i++) {
+            try {
+                omegaContext.newGlobalTxId();
+                HystrixCommand<String> command = new HystrixConcurrencyStrategyTests.TestCircuitBreakerCommand("testCircuitBreaker", omegaContext);
+                String result = command.execute();
+                //因为线程池核心数是3，所以第三次以后globalTxId将不一致
+                if (i > 2) {
+                    Assert.assertNotEquals(result, omegaContext.globalTxId());
+                } else {
+                    Assert.assertEquals(result, omegaContext.globalTxId());
+                }
+            } finally {
+                omegaContext.clear();
+            }
+        }
+    }
+
+
+}

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
@@ -29,27 +29,28 @@ import org.junit.Test;
 
 public class HystrixWithoutConcurrencyStrategyTests {
 
-    private OmegaContext omegaContext = new OmegaContext(new UniqueIdGenerator());
+  private OmegaContext omegaContext = new OmegaContext(new UniqueIdGenerator());
 
-    @Test
-    public void testCircuitBreakerWithoutServiceCombConcurrencyStrategy() {
+  @Test
+  public void testCircuitBreakerWithoutServiceCombConcurrencyStrategy() {
 
-        for (int i = 0; i < 5; i++) {
-            try {
-                omegaContext.newGlobalTxId();
-                HystrixCommand<String> command = new HystrixConcurrencyStrategyTests.TestCircuitBreakerCommand("testCircuitBreaker", omegaContext);
-                String result = command.execute();
-                //after core thread all invoked (3 times) ,globalTxId can not be inheritable
-                if (i > 2) {
-                    Assert.assertNotEquals(result, omegaContext.globalTxId());
-                } else {
-                    Assert.assertEquals(result, omegaContext.globalTxId());
-                }
-            } finally {
-                omegaContext.clear();
-            }
+    for (int i = 0; i < 5; i++) {
+      try {
+        omegaContext.newGlobalTxId();
+        HystrixCommand<String> command = new HystrixConcurrencyStrategyTests.TestCircuitBreakerCommand(
+            "testCircuitBreaker", omegaContext);
+        String result = command.execute();
+        //after core thread all invoked (3 times) ,globalTxId can not be inheritable
+        if (i > 2) {
+          Assert.assertNotEquals(result, omegaContext.globalTxId());
+        } else {
+          Assert.assertEquals(result, omegaContext.globalTxId());
         }
+      } finally {
+        omegaContext.clear();
+      }
     }
+  }
 
 
 }

--- a/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
+++ b/omega/omega-transport/omega-transport-hystrix/src/test/java/org/apache/servicecomb/pack/omega/transport/hystrix/HystrixWithoutConcurrencyStrategyTests.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * 默认策略下，omegaContext的线程变量无法正确传递
+ * when not use ServiceCombConcurrencyStrategy ,threadLocal variables can not be inheritable
  */
 
 public class HystrixWithoutConcurrencyStrategyTests {
@@ -38,7 +39,7 @@ public class HystrixWithoutConcurrencyStrategyTests {
                 omegaContext.newGlobalTxId();
                 HystrixCommand<String> command = new HystrixConcurrencyStrategyTests.TestCircuitBreakerCommand("testCircuitBreaker", omegaContext);
                 String result = command.execute();
-                //因为线程池核心数是3，所以第三次以后globalTxId将不一致
+                //after core thread all invoked (3 times) ,globalTxId can not be inheritable
                 if (i > 2) {
                     Assert.assertNotEquals(result, omegaContext.globalTxId());
                 } else {

--- a/omega/omega-transport/pom.xml
+++ b/omega/omega-transport/pom.xml
@@ -36,6 +36,7 @@
     <module>omega-transport-servicecomb</module>
     <module>omega-transport-dubbo</module>
     <module>omega-transport-feign</module>
+    <module>omega-transport-hystrix</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,11 @@
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.netflix.hystrix</groupId>
+        <artifactId>hystrix-core</artifactId>
+        <version>1.5.12</version>
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <netty.version>4.1.24.Final</netty.version>
     <zookeeper.version>3.4.13</zookeeper.version>
     <kafka.version>2.1.1</kafka.version>
+    <hystrix.version>1.5.12</hystrix.version>
   </properties>
 
   <name>ServiceComb Saga</name>
@@ -537,7 +538,7 @@
       <dependency>
         <groupId>com.netflix.hystrix</groupId>
         <artifactId>hystrix-core</artifactId>
-        <version>1.5.12</version>
+        <version>${hystrix.version}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
解决issue #571
我关闭了 #572 ,重新提交了PR
OmegaContext 中使用了 InheritableThreadLocal
在feign调用开启hystrix时,hystrix会为每个feignClient创建线程池.
InheritableThreadLocal在第一次创建线程时,可以正确继承到父线程的线程变量,但是当线程被复用时,InheritableThreadLocal不会被更新,导致无法在feign调用的header里传递globalTxId和localTxId

我参考了spring security解决securityContext 线程变量在使用hystrix时,传递线程变量的方案,针对OmegaContext里的线程变量进行了传递,并提供了可扩展的接口