### PR TITLE
SCB-1602:added tar file mode

### DIFF
--- a/docker-build-config/pom.xml
+++ b/docker-build-config/pom.xml
@@ -46,6 +46,7 @@
                     <port>8080</port>
                   </ports>
                   <assembly>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <mode>tar</mode>
                     <descriptor>${root.basedir}/docker-build-config/assembly/assembly.xml
                     </descriptor>


### PR DESCRIPTION
Changed pom of docker-build-config to support tar long file mode
---
