### PR TITLE
[SCB-1611] metric system.load.average.1m does not support windows os

### DIFF
--- a/alpha/alpha-ui/src/main/java/org/apache/servicecomb/pack/alpha/ui/controller/IndexController.java
+++ b/alpha/alpha-ui/src/main/java/org/apache/servicecomb/pack/alpha/ui/controller/IndexController.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.servicecomb.pack.alpha.ui.vo.SystemInfoDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
+import org.springframework.boot.actuate.metrics.MetricsEndpoint.MetricResponse;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint.Sample;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.stereotype.Controller;
@@ -86,10 +87,11 @@ public class IndexController implements ErrorController {
         metricsEndpoint.metric("system.cpu.count", null).getMeasurements().get(0).getValue()
             .intValue());
 
-    //system load
-    systemInfoDTO.setSystemLoad(Math.round(
-        metricsEndpoint.metric("system.load.average.1m", null).getMeasurements().get(0).getValue()
-            .floatValue() * 100) / (float)100);
+    //system load window os not support
+    MetricResponse metricResponse = metricsEndpoint.metric("system.load.average.1m", null);
+    if (metricResponse != null) {
+      systemInfoDTO.setSystemLoad(Math.round(metricResponse.getMeasurements().get(0).getValue().floatValue() * 100) / (float) 100);
+    }
 
     //thread
     systemInfoDTO.setThreadsLive(


### PR DESCRIPTION
metric system.load.average.1m does not support windows os[1], Ignore the metric when running in windows

https://github.com/micrometer-metrics/micrometer/blob/6d615c4af01dcc8bf9e9b4d64c5bce7aba23b444/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java#L32