### PR TITLE
[SCB-1658] Improve encapsulation on txEntityMap of SagaData

### DIFF
--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/SagaData.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/SagaData.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.servicecomb.pack.alpha.core.fsm.SuspendedType;
 import org.apache.servicecomb.pack.alpha.fsm.SagaActorState;
@@ -39,7 +38,7 @@ public class SagaData implements Serializable {
   private boolean terminated;
   private SagaActorState lastState;
   private AtomicLong compensationRunningCounter = new AtomicLong();
-  private ConcurrentSkipListMap<String,TxEntity> txEntityMap = new ConcurrentSkipListMap<>();
+  private TxEntities txEntities = new TxEntities();
   private List<BaseEvent> events = new LinkedList<>();
 
   public String getServiceName() {
@@ -119,13 +118,12 @@ public class SagaData implements Serializable {
     this.compensationRunningCounter = compensationRunningCounter;
   }
 
-  public ConcurrentSkipListMap<String, TxEntity> getTxEntityMap() {
-    return txEntityMap;
+  public TxEntities getTxEntities() {
+    return txEntities;
   }
 
-  public void setTxEntityMap(
-      ConcurrentSkipListMap<String, TxEntity> txEntityMap) {
-    this.txEntityMap = txEntityMap;
+  public void setTxEntities(TxEntities txEntities) {
+    this.txEntities = txEntities;
   }
 
   public SagaActorState getLastState() {
@@ -195,11 +193,10 @@ public class SagaData implements Serializable {
       return this;
     }
 
-    public Builder txEntityMap(ConcurrentSkipListMap<String, TxEntity> txEntityMap) {
-      sagaData.setTxEntityMap(txEntityMap);
+    public Builder txEntities(TxEntities txEntities) {
+      sagaData.setTxEntities(txEntities);
       return this;
     }
-
     public Builder serviceName(String serviceName) {
       sagaData.setServiceName(serviceName);
       return this;

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.fsm.model;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.BiConsumer;
+import org.apache.servicecomb.pack.alpha.core.fsm.TxState;
+
+public class TxEntities {
+
+  private ConcurrentSkipListMap<String, TxEntity> entities = new ConcurrentSkipListMap<>();
+
+  public void forEach(BiConsumer<String, TxEntity> action) {
+    entities.forEach(action);
+  }
+
+  public void forEachReverse(BiConsumer<String, TxEntity> action) {
+    entities.descendingMap().forEach(action);
+  }
+
+  public TxEntity get(String localTxId) {
+    return entities.get(localTxId);
+  }
+
+  public boolean exists(String localTxId) {
+    return entities.containsKey(localTxId);
+  }
+
+  public TxEntity put(String localTxId, TxEntity txEntity) {
+    return entities.put(localTxId, txEntity);
+  }
+
+  public int size() {
+    return entities.size();
+  }
+
+  public boolean hasCommittedTx() {
+    return entities.entrySet().stream()
+        .filter(map -> map.getValue().getState() == TxState.COMMITTED)
+        .count() > 0;
+  }
+
+  public boolean hasCompensationSentTx() {
+    return entities.entrySet().stream()
+        .filter(map -> map.getValue().getState() == TxState.COMPENSATION_SENT)
+        .count() > 0;
+  }
+}

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/spring/integration/akka/SagaDataExtension.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/spring/integration/akka/SagaDataExtension.java
@@ -66,7 +66,7 @@ public class SagaDataExtension extends AbstractExtensionId<SagaDataExt> {
         this.metricsService.metrics().doSuspended();
       }
       List<SagaSubTransaction> subTransactions = new ArrayList();
-      sagaData.getTxEntityMap().forEach((k,v)->{
+      sagaData.getTxEntities().forEach((k,v)->{
         subTransactions.add(SagaSubTransaction.builder()
             .parentTxId(v.getParentTxId())
             .localTxId(v.getLocalTxId())
@@ -83,7 +83,7 @@ public class SagaDataExtension extends AbstractExtensionId<SagaDataExt> {
           .beginTime(sagaData.getBeginTime())
           .endTime(sagaData.getEndTime())
           .state(sagaData.getLastState().name())
-          .subTxSize(sagaData.getTxEntityMap().size())
+          .subTxSize(sagaData.getTxEntities().size())
           .subTransactions(subTransactions)
           .events(sagaData.getEvents())
           .suspendedType(sagaData.getSuspendedType())

--- a/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/SagaActorTest.java
+++ b/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/SagaActorTest.java
@@ -173,8 +173,8 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      sagaData.getTxEntityMap().forEach((k, v) -> {
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      sagaData.getTxEntities().forEach((k, v) -> {
         assertEquals(v.getState(), TxState.COMMITTED);
       });
       assertThat(eventList, is(sagaData.getEvents()));
@@ -260,8 +260,8 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      sagaData.getTxEntityMap().forEach((k, v) -> {
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      sagaData.getTxEntities().forEach((k, v) -> {
         assertEquals(v.getState(), TxState.COMMITTED);
       });
       eventListFirst.addAll(eventListSecond);
@@ -312,8 +312,8 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 1);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().size(), 1);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.FAILED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
       assertThat(eventList, is(sagaData.getEvents()));
 
@@ -374,9 +374,9 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 2);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().size(), 2);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.FAILED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
 
       assertThat(eventList, is(sagaData.getEvents()));
@@ -447,10 +447,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.FAILED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
       assertThat(eventList, is(sagaData.getEvents()));
 
@@ -520,10 +520,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.FAILED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
 
       assertThat(eventList, is(sagaData.getEvents()));
@@ -582,10 +582,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.FAILED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.COMPENSATED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
       assertThat(eventList, is(sagaData.getEvents()));
 
@@ -660,10 +660,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.COMPENSATED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
 
       assertThat(eventList, is(sagaData.getEvents()));
@@ -733,10 +733,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMMITTED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMMITTED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.COMMITTED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMMITTED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMMITTED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.COMMITTED);
       assertThat(eventList, is(sagaData.getEvents()));
 
       system.stop(saga);
@@ -856,8 +856,8 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      sagaData.getTxEntityMap().forEach((k, v) -> {
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      sagaData.getTxEntities().forEach((k, v) -> {
         assertEquals(v.getState(), TxState.COMMITTED);
       });
       assertThat(eventList, is(sagaData.getEvents()));
@@ -919,8 +919,8 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      sagaData.getTxEntityMap().forEach((k, v) -> {
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      sagaData.getTxEntities().forEach((k, v) -> {
         assertEquals(v.getState(), TxState.COMMITTED);
       });
       assertThat(eventList, is(sagaData.getEvents()));
@@ -981,10 +981,10 @@ public class SagaActorTest {
 
       SagaData sagaData = SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       assertEquals(sagaData.getGlobalTxId(), globalTxId);
-      assertEquals(sagaData.getTxEntityMap().size(), 3);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(), TxState.COMPENSATED);
-      assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(), TxState.FAILED);
+      assertEquals(sagaData.getTxEntities().size(), 3);
+      assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(), TxState.COMPENSATED);
+      assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(), TxState.FAILED);
       assertEquals(sagaData.getCompensationRunningCounter().intValue(), 0);
       assertThat(eventList, is(sagaData.getEvents()));
 

--- a/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/SagaIntegrationTest.java
+++ b/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/SagaIntegrationTest.java
@@ -92,10 +92,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(), TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(), TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
     assertEquals(metricsService.metrics().getActorReceived(),8);
     assertEquals(metricsService.metrics().getActorAccepted(),8);
     assertEquals(metricsService.metrics().getSagaBeginCounter(),1);
@@ -117,8 +117,8 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),1);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().size(),1);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.FAILED);
   }
 
   @Test
@@ -136,9 +136,9 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),2);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().size(),2);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.FAILED);
   }
 
   @Test
@@ -157,10 +157,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
   }
 
   @Test
@@ -179,10 +179,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
   }
 
   @Test
@@ -201,10 +201,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.FAILED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMPENSATED);
   }
 
   @Test
@@ -223,10 +223,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMPENSATED);
   }
 
   @Test
@@ -245,10 +245,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -268,10 +268,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -290,10 +290,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -312,10 +312,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -334,10 +334,10 @@ public class SagaIntegrationTest {
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
-    assertEquals(sagaData.getTxEntityMap().size(),3);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().size(),3);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
   }
 
 }

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/fsm/AlphaIntegrationFsmTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/fsm/AlphaIntegrationFsmTest.java
@@ -129,13 +129,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.COMMITTED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -152,11 +152,11 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),1);
+    assertEquals(sagaData.getTxEntities().size(),1);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.FAILED);
   }
 
   @Test
@@ -175,12 +175,12 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),2);
+    assertEquals(sagaData.getTxEntities().size(),2);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.FAILED);
   }
 
   @Test
@@ -200,14 +200,14 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
-    assertArrayEquals(sagaData.getTxEntityMap().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
+    assertArrayEquals(sagaData.getTxEntities().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
   }
 
   @Test
@@ -227,13 +227,13 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.FAILED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMPENSATED);
   }
 
   @Test
@@ -260,13 +260,13 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.FAILED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMPENSATED);
   }
 
   @Test
@@ -286,13 +286,13 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMPENSATED);
   }
 
   @Test
@@ -310,13 +310,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.SUSPENDED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -335,13 +335,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.SUSPENDED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -359,13 +359,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.COMMITTED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -383,13 +383,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.COMMITTED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMMITTED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMMITTED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.COMMITTED);
   }
 
   @Test
@@ -408,13 +408,13 @@ public class AlphaIntegrationFsmTest {
       return sagaData !=null && sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.COMPENSATED;
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
   }
 
   @Test
@@ -434,13 +434,13 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
   }
 
   @Test
@@ -464,7 +464,7 @@ public class AlphaIntegrationFsmTest {
     //simulate omega connected
     await().atMost(5, SECONDS).until(() -> {
       SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
-      return sagaData !=null && sagaData.getTxEntityMap().size()==3;
+      return sagaData !=null && sagaData.getTxEntities().size()==3;
     });
     omegaEventSender.getOmegaCallbacks().put(serviceName[0], omegaInstance[0]);
     waitAlphaCallCompensate(omegaEventSender, globalTxId, localTxId_1, localTxId_2);
@@ -474,14 +474,14 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
-    assertArrayEquals(sagaData.getTxEntityMap().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
+    assertArrayEquals(sagaData.getTxEntities().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
   }
 
   @Test
@@ -501,14 +501,14 @@ public class AlphaIntegrationFsmTest {
     });
     SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
     assertEquals(sagaData.getLastState(),SagaActorState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().size(),3);
+    assertEquals(sagaData.getTxEntities().size(),3);
     assertNotNull(sagaData.getBeginTime());
     assertNotNull(sagaData.getEndTime());
     assertTrue(sagaData.getEndTime().getTime() > sagaData.getBeginTime().getTime());
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_1).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_2).getState(),TxState.COMPENSATED);
-    assertEquals(sagaData.getTxEntityMap().get(localTxId_3).getState(),TxState.FAILED);
-    assertArrayEquals(sagaData.getTxEntityMap().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
+    assertEquals(sagaData.getTxEntities().get(localTxId_1).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_2).getState(),TxState.COMPENSATED);
+    assertEquals(sagaData.getTxEntities().get(localTxId_3).getState(),TxState.FAILED);
+    assertArrayEquals(sagaData.getTxEntities().get(localTxId_3).getThrowablePayLoads(),NullPointerException.class.getName().getBytes());
   }
 
   /**


### PR DESCRIPTION
Hide the sub-transaction entity details of SagaData by the TxEntities class encapsulation implemented

PR origin: https://github.com/apache/servicecomb-pack/pull/609/files/ed35f7731cbabc762a8dd40dab4651cc7ee26b16#diff-33cf688727150d4153d7fbf08746a450