### PR TITLE
SCB-1669 Fixed reverse compensation sort bug in FSM

### DIFF
--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/SagaActor.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/SagaActor.java
@@ -534,7 +534,7 @@ public class SagaActor extends
     txEntity.setState(TxState.COMPENSATION_SENT);
     try {
       SpringAkkaExtension.SPRING_EXTENSION_PROVIDER.get(context().system()).compensate(txEntity);
-      LOG.info("compensate {}", txEntity.getLocalTxId());
+      LOG.info("compensate {} {} {}", txEntity.getServiceName(), txEntity.getInstanceId(), txEntity.getLocalTxId());
     } catch (AlphaException ex) {
       LOG.error(ex.getMessage(), ex);
       try {

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
@@ -17,20 +17,27 @@
 
 package org.apache.servicecomb.pack.alpha.fsm.model;
 
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.ListIterator;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import org.apache.servicecomb.pack.alpha.core.fsm.TxState;
 
 public class TxEntities {
 
-  private ConcurrentSkipListMap<String, TxEntity> entities = new ConcurrentSkipListMap<>();
+  private LinkedHashMap<String, TxEntity> entities = new LinkedHashMap<>();
 
   public void forEach(BiConsumer<String, TxEntity> action) {
     entities.forEach(action);
   }
 
   public void forEachReverse(BiConsumer<String, TxEntity> action) {
-    entities.descendingMap().forEach(action);
+    ListIterator<Map.Entry<String, TxEntity>> iterator = new ArrayList<>(entities.entrySet()).listIterator(entities.size());
+    while (iterator.hasPrevious()) {
+      Map.Entry<String, TxEntity> entry = iterator.previous();
+      action.accept(entry.getKey(),entry.getValue());
+    }
   }
 
   public TxEntity get(String localTxId) {

--- a/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntitiesTest.java
+++ b/alpha/alpha-fsm/src/test/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntitiesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.pack.alpha.fsm.model;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.UUID;
+import org.junit.Test;
+
+public class TxEntitiesTest {
+
+  @Test
+  public void testForEachReverse(){
+    TxEntity t1 = TxEntity.builder().beginTime(new Date(System.currentTimeMillis())).build();
+    TxEntity t2 = TxEntity.builder().beginTime(new Date(System.currentTimeMillis()+10)).build();
+    TxEntity t3 = TxEntity.builder().beginTime(t2.getBeginTime()).build(); // beginTime same t2
+    TxEntity t4 = TxEntity.builder().beginTime(new Date(System.currentTimeMillis()+20)).build();
+    List<TxEntity> entities = Lists.newArrayList(t4, t3, t2, t1);
+    // t1,t2,t3,t4
+    TxEntities txEntities = new TxEntities();
+    ListIterator<TxEntity> iterator = entities.listIterator(entities.size());
+    while(iterator.hasPrevious()){
+      entities.forEach(t->txEntities.put(UUID.randomUUID().toString(),iterator.previous()));
+    }
+    // t4,t3,t2,t1
+    List<TxEntity> reverseEntities = new ArrayList();
+    txEntities.forEachReverse((k,v)->{
+      reverseEntities.add(v);
+    });
+    assertTrue(Iterables.elementsEqual(entities, reverseEntities));
+  }
+}


### PR DESCRIPTION
The order of execution of reverse compensation should be reversed from the start time of the sub-transaction