### PR TITLE
[SCB-1685] Change Assert method contains to containsInAnyOrder

### DIFF
--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.apache.servicecomb.pack.common.EventType.TxCompensatedEvent;
 import static org.apache.servicecomb.pack.common.EventType.TxEndedEvent;
 import static org.apache.servicecomb.pack.common.EventType.TxStartedEvent;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -286,7 +286,7 @@ public class AlphaIntegrationTest {
     blockingStub.onTxEvent(someGrpcEvent(TxAbortedEvent));
     await().atMost(1, SECONDS).until(() -> receivedCommandsCounter.get() > 1);
 
-    assertThat(receivedCommands, contains(
+    assertThat(receivedCommands, hasItems(
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId1).setParentTxId(parentTxId1)
             .setCompensationMethod("method b").setPayloads(ByteString.copyFrom("service b".getBytes())).build(),
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId).setParentTxId(parentTxId)

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.apache.servicecomb.pack.common.EventType.TxCompensatedEvent;
 import static org.apache.servicecomb.pack.common.EventType.TxEndedEvent;
 import static org.apache.servicecomb.pack.common.EventType.TxStartedEvent;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -286,7 +286,7 @@ public class AlphaIntegrationTest {
     blockingStub.onTxEvent(someGrpcEvent(TxAbortedEvent));
     await().atMost(1, SECONDS).until(() -> receivedCommandsCounter.get() > 1);
 
-    assertThat(receivedCommands, hasItems(
+    assertThat(receivedCommands, containsInAnyOrder(
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId1).setParentTxId(parentTxId1)
             .setCompensationMethod("method b").setPayloads(ByteString.copyFrom("service b".getBytes())).build(),
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId).setParentTxId(parentTxId)

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationWithRandomPortTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationWithRandomPortTest.java
@@ -48,7 +48,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.servicecomb.pack.alpha.core.TaskStatus.DONE;
 import static org.apache.servicecomb.pack.common.EventType.*;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -270,7 +270,7 @@ public class AlphaIntegrationWithRandomPortTest {
     blockingStub.onTxEvent(someGrpcEvent(TxAbortedEvent));
     await().atMost(2, SECONDS).until(() -> receivedCommandsCounter.get() > 1);
 
-    assertThat(receivedCommands, contains(
+    assertThat(receivedCommands, hasItems(
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId1).setParentTxId(parentTxId1)
             .setCompensationMethod("method b").setPayloads(ByteString.copyFrom("service b".getBytes())).build(),
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId).setParentTxId(parentTxId)

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationWithRandomPortTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/AlphaIntegrationWithRandomPortTest.java
@@ -48,7 +48,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.servicecomb.pack.alpha.core.TaskStatus.DONE;
 import static org.apache.servicecomb.pack.common.EventType.*;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -270,7 +270,7 @@ public class AlphaIntegrationWithRandomPortTest {
     blockingStub.onTxEvent(someGrpcEvent(TxAbortedEvent));
     await().atMost(2, SECONDS).until(() -> receivedCommandsCounter.get() > 1);
 
-    assertThat(receivedCommands, hasItems(
+    assertThat(receivedCommands, containsInAnyOrder(
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId1).setParentTxId(parentTxId1)
             .setCompensationMethod("method b").setPayloads(ByteString.copyFrom("service b".getBytes())).build(),
         GrpcCompensateCommand.newBuilder().setGlobalTxId(globalTxId).setLocalTxId(localTxId).setParentTxId(parentTxId)


### PR DESCRIPTION
Because the table scan mode cannot guarantee the order of asynchronous compensation messages, test case doNotCompensateDuplicateTxOnFailure will occasionally fail on CI

```bash
Failed tests: 
  AlphaIntegrationTest.doNotCompensateDuplicateTxOnFailure:289 
Expected: iterable containing [<globalTxId: "b402c45a-ef25-4061-a5d7-a25eff120c3d"
localTxId: "1f438adb-6b62-41f6-bcc6-e11c791b918f"
parentTxId: "70f07983-0aa6-4fc2-99b0-545b43e7c214"
compensationMethod: "method b"
payloads: "service b"
>, <globalTxId: "b402c45a-ef25-4061-a5d7-a25eff120c3d"
localTxId: "a4eafa18-fcdf-4363-b5dd-a9e647096e15"
parentTxId: "bb87ca5b-1fc8-45fe-931e-67eb8e13405f"
compensationMethod: "method a"
payloads: "service a"
>]
     but: item 0: was <globalTxId: "b402c45a-ef25-4061-a5d7-a25eff120c3d"
localTxId: "a4eafa18-fcdf-4363-b5dd-a9e647096e15"
parentTxId: "bb87ca5b-1fc8-45fe-931e-67eb8e13405f"
compensationMethod: "method a"
payloads: "service a"
>
Tests run: 104, Failures: 1, Errors: 0, Skipped: 0
```
