### PR TITLE
SCB-1690 omega-transport-resttemplate does not use RestTemplateBuilder

### DIFF
--- a/omega/omega-transport/omega-transport-resttemplate/pom.xml
+++ b/omega/omega-transport/omega-transport-resttemplate/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
     </dependency>

--- a/omega/omega-transport/omega-transport-resttemplate/src/main/java/org/apache/servicecomb/pack/omega/transport/resttemplate/RestTemplateConfig.java
+++ b/omega/omega-transport/omega-transport-resttemplate/src/main/java/org/apache/servicecomb/pack/omega/transport/resttemplate/RestTemplateConfig.java
@@ -18,25 +18,22 @@
 
 package org.apache.servicecomb.pack.omega.transport.resttemplate;
 
-import java.util.List;
-
+import org.apache.servicecomb.pack.omega.context.OmegaContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
-
-import org.apache.servicecomb.pack.omega.context.OmegaContext;
 
 @Configuration
 public class RestTemplateConfig {
 
   @Bean(name = "omegaRestTemplate")
-  public RestTemplate omegaRestTemplate(@Autowired(required=false) OmegaContext context) {
-    RestTemplate template = new RestTemplate();
-    List<ClientHttpRequestInterceptor> interceptors = template.getInterceptors();
-    interceptors.add(new TransactionClientHttpRequestInterceptor(context));
-    template.setInterceptors(interceptors);
-    return template;
+  public RestTemplate omegaRestTemplate(@Autowired(required = false) OmegaContext context,
+      RestTemplateBuilder restTemplateBuilder) {
+    return restTemplateBuilder
+        .additionalInterceptors(new TransactionClientHttpRequestInterceptor(context))
+        .build();
   }
+
 }


### PR DESCRIPTION
Issue details: https://issues.apache.org/jira/browse/SCB-1690

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
