### PR TITLE
[SCB-1695] Add attribute mode to @Compensable annotation

### DIFF
--- a/docs/upgrade_guide/0.6.0-upgrade-guide.md
+++ b/docs/upgrade_guide/0.6.0-upgrade-guide.md
@@ -8,3 +8,8 @@ Rename @Compensable annotation property `retries`  to `forwardRetries`
 
 Rename @Compensable annotation property `timeout`  to `forwardTimeout`
 
+Add attribute `mode` to @Compensable annotation, There are three options for attribute values
+
+- forward, it will use the forward recovery
+- reverse, it will use the reverse recovery (default)
+- combine, it will use the first forward then reverse

--- a/docs/upgrade_guide/0.6.0-upgrade-guide_zh.md
+++ b/docs/upgrade_guide/0.6.0-upgrade-guide_zh.md
@@ -8,3 +8,9 @@
 
 @Compensable 注解的 `timeout` 属性改名为 `forwardTimeout`
 
+@Compensable 增加 `mode` 属性 ，可选属性值为以下三种
+
+- forward 正向补偿
+- reverse 反向补偿（默认）
+- combine 组合补偿（先正向补偿，后反向补偿）
+

--- a/integration-tests/explicit-transaction-context-tests/src/test/java/org/apache/servicecomb/pack/integration/tests/explicitcontext/GreetingService.java
+++ b/integration-tests/explicit-transaction-context-tests/src/test/java/org/apache/servicecomb/pack/integration/tests/explicitcontext/GreetingService.java
@@ -21,6 +21,7 @@ import java.util.Queue;
 
 import org.apache.servicecomb.pack.omega.context.TransactionContext;
 import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -63,7 +64,7 @@ class GreetingService  {
     return appendMessage("My bad, please take the window instead, " + name);
   }
 
-  @Compensable(forwardRetries = MAX_COUNT, compensationMethod = "close")
+  @Compensable(mode = CompensableMode.forward, forwardRetries = MAX_COUNT, compensationMethod = "close")
   String open(String name, int retries, TransactionContext transactionContext) {
     if (failedCount < retries) {
       failedCount += 1;

--- a/integration-tests/pack-tests/src/test/java/org/apache/servicecomb/pack/integration/tests/resttemplate/GreetingService.java
+++ b/integration-tests/pack-tests/src/test/java/org/apache/servicecomb/pack/integration/tests/resttemplate/GreetingService.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.pack.integration.tests.resttemplate;
 import java.util.Queue;
 
 import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -62,7 +63,7 @@ class GreetingService {
     return appendMessage("My bad, please take the window instead, " + name);
   }
 
-  @Compensable(forwardRetries = MAX_COUNT, compensationMethod = "close")
+  @Compensable(mode = CompensableMode.forward, forwardRetries = MAX_COUNT, compensationMethod = "close")
   String open(String name, int retries) {
     if (failedCount < retries) {
       failedCount += 1;

--- a/omega/omega-spring-tx/src/test/java/org/apache/servicecomb/pack/omega/transaction/spring/TransactionalUserService.java
+++ b/omega/omega-spring-tx/src/test/java/org/apache/servicecomb/pack/omega/transaction/spring/TransactionalUserService.java
@@ -18,6 +18,7 @@
 package org.apache.servicecomb.pack.omega.transaction.spring;
 
 import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,7 +52,7 @@ public class TransactionalUserService {
     userRepository.delete(user);
   }
 
-  @Compensable(forwardRetries = 2, compensationMethod = "delete")
+  @Compensable(mode = CompensableMode.forward, forwardRetries = 2, compensationMethod = "delete")
   public User add(User user, int count) {
     if (this.count < count) {
       this.count += 1;

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/RecoveryPolicyFactory.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/RecoveryPolicyFactory.java
@@ -17,17 +17,19 @@
 
 package org.apache.servicecomb.pack.omega.transaction;
 
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
+
 public class RecoveryPolicyFactory {
   private static final RecoveryPolicy DEFAULT_RECOVERY = new DefaultRecovery();
 
   private static final RecoveryPolicy FORWARD_RECOVERY = new ForwardRecovery();
 
   /**
-   * If retries == 0, use the default recovery to execute only once.
-   * If retries > 0, it will use the forward recovery and retry the given times at most.
-   * If retries == -1, it will use the forward recovery and retry forever until interrupted.
+   * If mode is reverse, it will use the reverse recovery
+   * If mode is forward, it will use the forward recovery
+   * If mode is combine, it will use the first forward then reverse
    */
-  static RecoveryPolicy getRecoveryPolicy(int retries) {
-    return retries != 0 ? FORWARD_RECOVERY : DEFAULT_RECOVERY;
+  static RecoveryPolicy getRecoveryPolicy(CompensableMode mode) {
+    return mode == CompensableMode.forward ? FORWARD_RECOVERY : DEFAULT_RECOVERY;
   }
 }

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/TransactionAspect.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/TransactionAspect.java
@@ -63,10 +63,9 @@ public class TransactionAspect extends TransactionContextHelper {
     context.newLocalTxId();
     LOG.debug("Updated context {} for compensable method {} ", context, method.toString());
 
-    int retries = compensable.forwardRetries();
-    RecoveryPolicy recoveryPolicy = RecoveryPolicyFactory.getRecoveryPolicy(retries);
+    RecoveryPolicy recoveryPolicy = RecoveryPolicyFactory.getRecoveryPolicy(compensable.mode());
     try {
-      return recoveryPolicy.apply(joinPoint, compensable, interceptor, context, localTxId, retries);
+      return recoveryPolicy.apply(joinPoint, compensable, interceptor, context, localTxId, compensable.forwardRetries());
     } finally {
       context.setLocalTxId(localTxId);
       LOG.debug("Restored context back to {}", context);

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/annotations/Compensable.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/annotations/Compensable.java
@@ -73,4 +73,13 @@ public @interface Compensable {
    */
   int forwardTimeout() default 0;
 
+  /**
+   * Compensation mode. <br>
+   * Default value is reverse
+   * value is forward, it will use the forward recovery
+   * value is reverse, it will use the reverse recovery
+   * value is combine, first forward then reverse
+   * @return compensable mode enum value
+   */
+  CompensableMode mode() default CompensableMode.reverse;
 }

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/annotations/CompensableMode.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/pack/omega/transaction/annotations/CompensableMode.java
@@ -15,18 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.servicecomb.pack.omega.transaction.spring;
+package org.apache.servicecomb.pack.omega.transaction.annotations;
 
-import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
-import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
-@Profile("annotation-retries-checking")
-@Component
-class MisconfiguredRetriesService {
-
-  @Compensable(mode = CompensableMode.forward, forwardRetries = -2)
-  void doSomething() {
-  }
+public enum CompensableMode {
+  forward, reverse, combine
 }

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/DefaultRecoveryTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/DefaultRecoveryTest.java
@@ -21,7 +21,7 @@ import static com.seanyinx.github.unit.scaffolding.AssertUtils.expectFailing;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/ForwardRecoveryTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/ForwardRecoveryTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/ForwardRecoveryTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/ForwardRecoveryTest.java
@@ -40,6 +40,7 @@ import org.apache.servicecomb.pack.contract.grpc.ServerMeta;
 import org.apache.servicecomb.pack.omega.context.IdGenerator;
 import org.apache.servicecomb.pack.omega.context.OmegaContext;
 import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.Before;
@@ -144,6 +145,7 @@ public class ForwardRecoveryTest {
   @Test
   public void throwExceptionWhenRetryReachesMaximum() throws Throwable {
     when(compensable.forwardRetries()).thenReturn(2);
+    when(compensable.mode()).thenReturn(CompensableMode.forward);
     when(joinPoint.proceed()).thenThrow(oops);
 
     try {
@@ -166,6 +168,7 @@ public class ForwardRecoveryTest {
   public void keepRetryingTillInterrupted() throws Throwable {
     when(compensable.forwardRetries()).thenReturn(-1);
     when(compensable.retryDelayInMilliseconds()).thenReturn(1000);
+    when(compensable.mode()).thenReturn(CompensableMode.forward);
     when(joinPoint.proceed()).thenThrow(oops);
 
     Thread thread = new Thread(new Runnable() {

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/TransactionAspectTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/pack/omega/transaction/TransactionAspectTest.java
@@ -42,6 +42,7 @@ import org.apache.servicecomb.pack.omega.context.IdGenerator;
 import org.apache.servicecomb.pack.omega.context.OmegaContext;
 import org.apache.servicecomb.pack.omega.context.TransactionContextProperties;
 import org.apache.servicecomb.pack.omega.transaction.annotations.Compensable;
+import org.apache.servicecomb.pack.omega.transaction.annotations.CompensableMode;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.Before;
@@ -310,6 +311,7 @@ public class TransactionAspectTest {
     RuntimeException oops = new RuntimeException("oops");
     when(joinPoint.proceed()).thenThrow(oops);
     when(compensable.forwardRetries()).thenReturn(3);
+    when(compensable.mode()).thenReturn(CompensableMode.forward);
 
     try {
       aspect.advise(joinPoint, compensable);
@@ -354,6 +356,7 @@ public class TransactionAspectTest {
     RuntimeException oops = new RuntimeException("oops");
     when(joinPoint.proceed()).thenThrow(oops).thenThrow(oops).thenReturn(null);
     when(compensable.forwardRetries()).thenReturn(-1);
+    when(compensable.mode()).thenReturn(CompensableMode.forward);
 
     aspect.advise(joinPoint, compensable);
 


### PR DESCRIPTION
Add attribute `mode` to the @Compensable annotation, which contains three options:

- forward 
- reverse (default)
- combine (first forward then reverse)