### PR TITLE
[SCB-2004] Fix compensation retry failure during business service startup

### DIFF
--- a/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/fsm/event/internal/ComponsitedCheckEvent.java
+++ b/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/fsm/event/internal/ComponsitedCheckEvent.java
@@ -22,10 +22,10 @@ import org.apache.servicecomb.pack.alpha.core.fsm.event.base.TxEvent;
 
 public class ComponsitedCheckEvent extends TxEvent {
 
-  private TxState preState;
+  private TxState preComponsitedState;
 
-  public TxState getPreState() {
-    return preState;
+  public TxState getPreComponsitedState() {
+    return preComponsitedState;
   }
 
   public static Builder builder() {
@@ -66,7 +66,7 @@ public class ComponsitedCheckEvent extends TxEvent {
     }
 
     public Builder preState(TxState txState) {
-      txComponsitedEvent.preState = txState;
+      txComponsitedEvent.preComponsitedState = txState;
       return this;
     }
 

--- a/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/fsm/event/internal/ComponsitedCheckEvent.java
+++ b/alpha/alpha-core/src/main/java/org/apache/servicecomb/pack/alpha/core/fsm/event/internal/ComponsitedCheckEvent.java
@@ -17,9 +17,16 @@
 
 package org.apache.servicecomb.pack.alpha.core.fsm.event.internal;
 
+import org.apache.servicecomb.pack.alpha.core.fsm.TxState;
 import org.apache.servicecomb.pack.alpha.core.fsm.event.base.TxEvent;
 
 public class ComponsitedCheckEvent extends TxEvent {
+
+  private TxState preState;
+
+  public TxState getPreState() {
+    return preState;
+  }
 
   public static Builder builder() {
     return new Builder();
@@ -31,6 +38,36 @@ public class ComponsitedCheckEvent extends TxEvent {
 
     private Builder() {
       txComponsitedEvent = new ComponsitedCheckEvent();
+    }
+    
+    public Builder serviceName(String serviceName) {
+      txComponsitedEvent.setServiceName(serviceName);
+      return this;
+    }
+
+    public Builder instanceId(String instanceId) {
+      txComponsitedEvent.setInstanceId(instanceId);
+      return this;
+    }
+
+    public Builder parentTxId(String parentTxId) {
+      txComponsitedEvent.setParentTxId(parentTxId);
+      return this;
+    }
+
+    public Builder localTxId(String localTxId) {
+      txComponsitedEvent.setLocalTxId(localTxId);
+      return this;
+    }
+
+    public Builder globalTxId(String globalTxId) {
+      txComponsitedEvent.setGlobalTxId(globalTxId);
+      return this;
+    }
+
+    public Builder preState(TxState txState) {
+      txComponsitedEvent.preState = txState;
+      return this;
     }
 
     public ComponsitedCheckEvent build() {

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/domain/UpdateTxEventDomain.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/domain/UpdateTxEventDomain.java
@@ -67,7 +67,7 @@ public class UpdateTxEventDomain implements DomainEvent {
   public UpdateTxEventDomain(ComponsitedCheckEvent event) {
     this.event = event;
     this.localTxId = event.getLocalTxId();
-    this.state = event.getPreState();
+    this.state = event.getPreComponsitedState();
   }
 
   public String getLocalTxId() {

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/domain/UpdateTxEventDomain.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/domain/UpdateTxEventDomain.java
@@ -24,6 +24,7 @@ import org.apache.servicecomb.pack.alpha.core.fsm.event.TxCompensateAckSucceedEv
 import org.apache.servicecomb.pack.alpha.core.fsm.event.internal.CompensateAckTimeoutEvent;
 import org.apache.servicecomb.pack.alpha.core.fsm.event.TxEndedEvent;
 import org.apache.servicecomb.pack.alpha.core.fsm.event.base.BaseEvent;
+import org.apache.servicecomb.pack.alpha.core.fsm.event.internal.ComponsitedCheckEvent;
 
 public class UpdateTxEventDomain implements DomainEvent {
   private String localTxId;
@@ -61,6 +62,12 @@ public class UpdateTxEventDomain implements DomainEvent {
     this.localTxId = event.getLocalTxId();
     this.throwablePayLoads = event.getPayloads();
     this.state = TxState.COMPENSATED_FAILED;
+  }
+
+  public UpdateTxEventDomain(ComponsitedCheckEvent event) {
+    this.event = event;
+    this.localTxId = event.getLocalTxId();
+    this.state = event.getPreState();
   }
 
   public String getLocalTxId() {

--- a/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
+++ b/alpha/alpha-fsm/src/main/java/org/apache/servicecomb/pack/alpha/fsm/model/TxEntities.java
@@ -67,4 +67,12 @@ public class TxEntities {
         .filter(map -> map.getValue().getState() == TxState.COMPENSATION_SENT)
         .count() > 0;
   }
+
+  public boolean hasCompensationFailedTx() {
+    return entities.entrySet().stream()
+        .filter(map -> map.getValue().getState() == TxState.COMPENSATED_FAILED
+            && map.getValue().getReverseRetries() > 0
+            && map.getValue().getReverseRetries() > map.getValue().getRetriesCounter().get())
+        .count() > 0;
+  }
 }

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/fsm/GrpcOmegaCallback.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/pack/alpha/server/fsm/GrpcOmegaCallback.java
@@ -55,7 +55,7 @@ class GrpcOmegaCallback implements OmegaCallback {
       if (compensateAckCountDownLatch.getType() == CompensateAckType.Disconnected) {
         throw new CompensateConnectException("Omega connect exception");
       }else{
-        LOG.info("compensate ack "+ compensateAckCountDownLatch.getType().name());
+        LOG.debug("compensate ack "+ compensateAckCountDownLatch.getType().name());
         if(compensateAckCountDownLatch.getType() == CompensateAckType.Failed){
           throw new CompensateAckFailedException("An exception is thrown inside the compensation method");
         }

--- a/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/fsm/AlphaIntegrationFsmTest.java
+++ b/alpha/alpha-server/src/test/java/org/apache/servicecomb/pack/alpha/server/fsm/AlphaIntegrationFsmTest.java
@@ -497,7 +497,7 @@ public class AlphaIntegrationFsmTest {
     //simulate omega connected
     omegaEventSender.getOmegaCallbacks().put(serviceName[0], omegaInstance[0]);
 
-    await().atMost(10, SECONDS).until(() -> {
+    await().atMost(15, SECONDS).until(() -> {
       SagaData sagaData = SagaDataExtension.SAGA_DATA_EXTENSION_PROVIDER.get(system).getLastSagaData();
       if(sagaData != null){
         if(sagaData.isTerminated() && sagaData.getLastState()==SagaActorState.COMPENSATED){


### PR DESCRIPTION
* Use message-driven compensation retry instead of recursive compensation
* In Omega, if CallbackContenxt does not contain callbackMethod, send TxCompensateAckFailedEvent to Alpha instead of throwing NPE
