### PR TITLE
[SCB-2192] Updates dependencies to up able to build on ARM64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <akka-persistence-redis.version>0.4.0</akka-persistence-redis.version>
     <rat.version>0.12</rat.version>
     <maven.failsafe.version>2.19.1</maven.failsafe.version>
-    <grpc.version>1.22.0</grpc.version>
+    <grpc.version>1.35.0</grpc.version>
     <kryo.version>4.0.1</kryo.version>
     <javax.transaction.version>1.2</javax.transaction.version>
     <eclipse.link.version>2.7.1</eclipse.link.version>
@@ -71,9 +71,9 @@
     <jaxb.version>2.3.0</jaxb.version>
     <javax.activation.version>1.1.1</javax.activation.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-    <netty.boringssl.version>2.0.25.Final</netty.boringssl.version>
-    <netty.version>4.1.35.Final</netty.version>
-    <zookeeper.version>3.4.13</zookeeper.version>
+    <netty.boringssl.version>2.0.36.Final</netty.boringssl.version>
+    <netty.version>4.1.59.Final</netty.version>
+    <zookeeper.version>3.6.2</zookeeper.version>
     <kafka.version>2.1.1</kafka.version>
     <hystrix.version>1.5.12</hystrix.version>
     <openfeign.version>9.5.1</openfeign.version>


### PR DESCRIPTION
Grpc - from 1.22.0 to 1.35.0
Netty - from 4.1.35 to 4.1.59
Netty-BoringSSL - from 2.0.25 to 2.0.36
Zookeeper - from 3.4.13 to 3.6.2