### PR TITLE
[SCB-2248] Update jacoco version to 0.8.6 supports Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <javax.activation.version>1.1.1</javax.activation.version>
     <tomcat-annotations-api.version>6.0.53</tomcat-annotations-api.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
+    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <netty.boringssl.version>2.0.36.Final</netty.boringssl.version>
     <netty.version>4.1.59.Final</netty.version>
     <zookeeper.version>3.6.2</zookeeper.version>
@@ -733,7 +734,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.8</version>
+          <version>${jacoco-maven-plugin.version}</version>
           <executions>
             <execution>
               <id>default-prepare-agent</id>


### PR DESCRIPTION
Jacoco 0.7.x does not support Java 11 https://github.com/jacoco/jacoco/issues/551

Gitlab Actions master push build fails

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
Caused by: java.lang.RuntimeException: Class java/util/UUID could not be instrumented.
	at org.jacoco.agent.rt.internal_e5875b2.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:140)
	at org.jacoco.agent.rt.internal_e5875b2.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:101)
	at org.jacoco.agent.rt.internal_e5875b2.PreMain.createRuntime(PreMain.java:55)
	at org.jacoco.agent.rt.internal_e5875b2.PreMain.premain(PreMain.java:47)
	... 6 more
Caused by: java.lang.NoSuchFieldException: $jacocoAccess
	at java.base/java.lang.Class.getField(Class.java:1999)
	at org.jacoco.agent.rt.internal_e5875b2.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:138)
	... 9 more
*** java.lang.instrument ASSERTION FAILED ***: "result" with message agent load/premain call failed at ./src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 422
FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
Aborted (core dumped)
```


