### PR TITLE
SCB-2275 Fixed coveralls-maven-plugin fails on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,6 +730,13 @@
               </jacocoReport>
             </jacocoReports>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>javax.xml.bind</groupId>
+              <artifactId>jaxb-api</artifactId>
+              <version>2.2.4</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>


### PR DESCRIPTION
CI build fails with JDK 11 https://github.com/apache/servicecomb-pack/actions/runs/714189795

```
Error: Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project pack: Execution default-cli of goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report failed: A required class was missing while executing org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report: javax/xml/bind/DatatypeConverter
```
See also:

https://github.com/trautonen/coveralls-maven-plugin/issues/112