### PR TITLE
SCB-2477 Use CI friendly maven version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ target/
 
 #akka distributed data
 ddata-*
+
+#flatten-maven-plugin
+**/.flattened-pom.xml

--- a/acceptance-tests/acceptance-pack-akka-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-akka-spring-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-cluster-spring-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-dubbo-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-dubbo-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Pack:Acceptance Tests::Dubbo</name>

--- a/acceptance-tests/acceptance-pack-spring-demo-with-consul/pom.xml
+++ b/acceptance-tests/acceptance-pack-spring-demo-with-consul/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-spring-demo-with-nacos/pom.xml
+++ b/acceptance-tests/acceptance-pack-spring-demo-with-nacos/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-spring-demo-with-zookeeper/pom.xml
+++ b/acceptance-tests/acceptance-pack-spring-demo-with-zookeeper/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-spring-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-pack-tcc-spring-demo/pom.xml
+++ b/acceptance-tests/acceptance-pack-tcc-spring-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/acceptance-test-common/pom.xml
+++ b/acceptance-tests/acceptance-test-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>acceptance-tests</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/alpha/alpha-benchmark/pom.xml
+++ b/alpha/alpha-benchmark/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-core/pom.xml
+++ b/alpha/alpha-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-persistence-jpa/pom.xml
+++ b/alpha/alpha-persistence-jpa/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-server/pom.xml
+++ b/alpha/alpha-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spec-saga-akka/pom.xml
+++ b/alpha/alpha-spec-saga-akka/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spec-saga-db/pom.xml
+++ b/alpha/alpha-spec-saga-db/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spec-tcc-db/pom.xml
+++ b/alpha/alpha-spec-tcc-db/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spring-cloud-starter-consul/pom.xml
+++ b/alpha/alpha-spring-cloud-starter-consul/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spring-cloud-starter-eureka/pom.xml
+++ b/alpha/alpha-spring-cloud-starter-eureka/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spring-cloud-starter-nacos/pom.xml
+++ b/alpha/alpha-spring-cloud-starter-nacos/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-spring-cloud-starter-zookeeper/pom.xml
+++ b/alpha/alpha-spring-cloud-starter-zookeeper/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/alpha-ui/pom.xml
+++ b/alpha/alpha-ui/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>alpha</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alpha/pom.xml
+++ b/alpha/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/demo/saga-dubbo-demo/pom.xml
+++ b/demo/saga-dubbo-demo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>pack-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-dubbo-demo/service-api/pom.xml
+++ b/demo/saga-dubbo-demo/service-api/pom.xml
@@ -24,14 +24,14 @@
     <dependency>
       <groupId>org.apache.servicecomb.pack.demo</groupId>
       <artifactId>service-pub</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 
   <parent>
     <artifactId>saga-dubbo-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>service-api</artifactId>

--- a/demo/saga-dubbo-demo/service-pub/pom.xml
+++ b/demo/saga-dubbo-demo/service-pub/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>saga-dubbo-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-dubbo-demo/servicea/pom.xml
+++ b/demo/saga-dubbo-demo/servicea/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
     <artifactId>saga-dubbo-demo</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>servicea</artifactId>

--- a/demo/saga-dubbo-demo/serviceb/pom.xml
+++ b/demo/saga-dubbo-demo/serviceb/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.servicecomb.pack.demo</groupId>
       <artifactId>service-api</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
     <artifactId>saga-dubbo-demo</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>serviceb</artifactId>

--- a/demo/saga-dubbo-demo/servicec/pom.xml
+++ b/demo/saga-dubbo-demo/servicec/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.servicecomb.pack.demo</groupId>
       <artifactId>service-api</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
     <artifactId>saga-dubbo-demo</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>servicec</artifactId>

--- a/demo/saga-servicecomb-demo/pom.xml
+++ b/demo/saga-servicecomb-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-servicecomb-demo/scb-booking/pom.xml
+++ b/demo/saga-servicecomb-demo/scb-booking/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>saga-servicecomb-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-servicecomb-demo/scb-car/pom.xml
+++ b/demo/saga-servicecomb-demo/scb-car/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>saga-servicecomb-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-servicecomb-demo/scb-hotel/pom.xml
+++ b/demo/saga-servicecomb-demo/scb-hotel/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>saga-servicecomb-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-spring-demo/booking/pom.xml
+++ b/demo/saga-spring-demo/booking/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>saga-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-spring-demo/car/pom.xml
+++ b/demo/saga-spring-demo/car/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>saga-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-spring-demo/hotel/pom.xml
+++ b/demo/saga-spring-demo/hotel/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>saga-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/saga-spring-demo/pom.xml
+++ b/demo/saga-spring-demo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pack-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/tcc-spring-demo/inventory/pom.xml
+++ b/demo/tcc-spring-demo/inventory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>tcc-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/tcc-spring-demo/ordering/pom.xml
+++ b/demo/tcc-spring-demo/ordering/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>tcc-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/tcc-spring-demo/payment/pom.xml
+++ b/demo/tcc-spring-demo/payment/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tcc-spring-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/demo/tcc-spring-demo/pom.xml
+++ b/demo/tcc-spring-demo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pack-demo</artifactId>
     <groupId>org.apache.servicecomb.pack.demo</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,9 +19,10 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.apache.servicecomb.pack</groupId>
-      <artifactId>pack</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+        <artifactId>pack-dependencies</artifactId>
+        <groupId>org.apache.servicecomb.pack</groupId>
+        <version>${revision}</version>
+        <relativePath>../pack-dependencies</relativePath>
     </parent>
     <artifactId>apache-servicecomb-pack-distribution</artifactId>
     <name>Pack::Distribution</name>

--- a/docker-build-config/pom.xml
+++ b/docker-build-config/pom.xml
@@ -18,9 +18,10 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>pack</artifactId>
+    <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
+    <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/coverage-aggregate/pom.xml
+++ b/integration-tests/coverage-aggregate/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.servicecomb.pack.tests</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -76,12 +76,12 @@
     <dependency>
       <groupId>org.apache.servicecomb.pack.tests</groupId>
       <artifactId>pack-tests</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.servicecomb.pack.tests</groupId>
       <artifactId>explicit-transaction-context-tests</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/integration-tests/explicit-transaction-context-tests/pom.xml
+++ b/integration-tests/explicit-transaction-context-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>integration-tests</artifactId>
     <groupId>org.apache.servicecomb.pack.tests</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pack-tests/pom.xml
+++ b/integration-tests/pack-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>integration-tests</artifactId>
     <groupId>org.apache.servicecomb.pack.tests</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/omega/omega-connector/omega-connector-grpc/pom.xml
+++ b/omega/omega-connector/omega-connector-grpc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>omega-connector</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-connector/pom.xml
+++ b/omega/omega-connector/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-context/pom.xml
+++ b/omega/omega-context/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-format/pom.xml
+++ b/omega/omega-format/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-cloud-consul-starter/pom.xml
+++ b/omega/omega-spring-cloud-consul-starter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-cloud-eureka-starter/pom.xml
+++ b/omega/omega-spring-cloud-eureka-starter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-cloud-nacos-starter/pom.xml
+++ b/omega/omega-spring-cloud-nacos-starter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-cloud-zookeeper-starter/pom.xml
+++ b/omega/omega-spring-cloud-zookeeper-starter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-starter/pom.xml
+++ b/omega/omega-spring-starter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-spring-tx/pom.xml
+++ b/omega/omega-spring-tx/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transaction/pom.xml
+++ b/omega/omega-transaction/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/omega-transport-dubbo/pom.xml
+++ b/omega/omega-transport/omega-transport-dubbo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>omega-transport</artifactId>
         <groupId>org.apache.servicecomb.pack</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/omega-transport-feign/pom.xml
+++ b/omega/omega-transport/omega-transport-feign/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>omega-transport</artifactId>
         <groupId>org.apache.servicecomb.pack</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/omega-transport-hystrix/pom.xml
+++ b/omega/omega-transport/omega-transport-hystrix/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>omega-transport</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/omega-transport-resttemplate/pom.xml
+++ b/omega/omega-transport/omega-transport-resttemplate/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>omega-transport</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/omega-transport-servicecomb/pom.xml
+++ b/omega/omega-transport/omega-transport-servicecomb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>omega-transport</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/omega-transport/pom.xml
+++ b/omega/omega-transport/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>omega</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/omega/pom.xml
+++ b/omega/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pack-common/pom.xml
+++ b/pack-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pack-contracts/pack-contract-grpc/pom.xml
+++ b/pack-contracts/pack-contract-grpc/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pack-contracts</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pack-contracts/pom.xml
+++ b/pack-contracts/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pack-dependencies/pom.xml
+++ b/pack-dependencies/pom.xml
@@ -847,6 +847,7 @@
   <build>
     <pluginManagement>
       <plugins>
+        <!-- Install or deploy artifacts with Maven CI Friendly Versions https://maven.apache.org/maven-ci-friendly.html#install-deploy -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>

--- a/pack-dependencies/pom.xml
+++ b/pack-dependencies/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -843,4 +843,52 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>${flatten-maven-plugin.version}</version>
+          <inherited>true</inherited>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+              <configuration>
+                <updatePomFile>true</updatePomFile>
+                <flattenMode>bom</flattenMode>
+                <pomElements>
+                  <parent>expand</parent>
+                  <dependencies>keep</dependencies>
+                  <dependencyManagement>keep</dependencyManagement>
+                  <pluginManagement>keep</pluginManagement>
+                  <distributionManagement>keep</distributionManagement>
+                  <repositories>keep</repositories>
+                  <properties>keep</properties>
+                </pomElements>
+              </configuration>
+            </execution>
+            <execution>
+              <id>flatten-clean</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <groupId>org.apache.servicecomb.pack</groupId>
   <artifactId>pack</artifactId>
   <packaging>pom</packaging>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <modules>
     <module>pack-dependencies</module>
@@ -45,7 +45,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-
+    <revision>0.7.0-SNAPSHOT</revision>
     <!-- plugins -->
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <license-maven-plugin.version>1.19</license-maven-plugin.version>
@@ -69,6 +69,7 @@
     <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
     <dependency-check-maven.version>6.5.3</dependency-check-maven.version>
+    <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
  </properties>
 
   <name>Apache ServiceComb Pack</name>
@@ -196,7 +197,7 @@
               <mixin>
                 <groupId>org.apache.servicecomb.pack</groupId>
                 <artifactId>docker-build-config</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
               </mixin>
             </mixins>
           </configuration>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pack-dependencies</artifactId>
     <groupId>org.apache.servicecomb.pack</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pack-dependencies</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
You can change the version via the command line when deploying like this:

```shell
./mvnw deploy -DskipTests -Ppassphrase -Prelease -Drevision=0.7.0
```

The rolling version only needs to modify the revision of the main pom file.

```xml
<properties>
    <revision>0.7.0-SNAPSHOT</revision>
</properties>
```
